### PR TITLE
Fix incorrect module path for asset news table

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -13,7 +13,7 @@ import { initToaster } from './ui/toast.js';
 import { buildMarketTable, renderMarketTable } from './ui/table.js';
 import { drawChart } from './ui/chart.js';
 import { renderInsight } from './ui/insight.js';
-import { renderAssetNewsTable } from './ui/newsAsset.js';
+import { renderAssetNewsTable } from './ui/newsAssets.js';
 import { showSummary } from './ui/modal.js';
 import { initRiskTools } from './ui/risktools.js';
 


### PR DESCRIPTION
## Summary
- correct app.js import to match `newsAssets.js` file name

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e5678d770832aba9a57a3ca2d237d