### PR TITLE
Place News & Events beneath asset list

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,23 +20,33 @@
 </header>
 
 <div class="grid">
-  <section class="card">
-    <div class="row" style="justify-content:space-between;align-items:center;margin-bottom:8px;">
-      <div class="mini">10‑second days • After‑hours news drives tomorrow</div>
-      <div class="row">
-        <button id="startBtn" class="accent">▶ Start Day</button>
-        <button id="saveBtn">Save</button>
-        <button id="resetBtn" class="bad">Hard Reset</button>
+  <section class="left-col">
+    <div class="card">
+      <div class="row" style="justify-content:space-between;align-items:center;margin-bottom:8px;">
+        <div class="mini">10‑second days • After‑hours news drives tomorrow</div>
+        <div class="row">
+          <button id="startBtn" class="accent">▶ Start Day</button>
+          <button id="saveBtn">Save</button>
+          <button id="resetBtn" class="bad">Hard Reset</button>
+        </div>
       </div>
+      <table id="marketTable">
+        <thead>
+          <tr>
+            <th>Asset</th><th>Price</th><th>Δ</th><th>Analyst</th><th>Holdings</th><th>Value</th><th>Trade</th>
+          </tr>
+        </thead>
+        <tbody id="tbody"></tbody>
+      </table>
     </div>
-    <table id="marketTable">
-      <thead>
-        <tr>
-          <th>Asset</th><th>Price</th><th>Δ</th><th>Analyst</th><th>Holdings</th><th>Value</th><th>Trade</th>
-        </tr>
-      </thead>
-      <tbody id="tbody"></tbody>
-    </table>
+
+    <div class="card">
+      <div class="row" style="justify-content:space-between;">
+        <div>News & Events — <b id="newsSymbol"></b></div>
+        <div class="mini">Follow the selected asset</div>
+      </div>
+      <div id="newsTable"></div>
+    </div>
   </section>
 
   <section class="right-col">
@@ -62,14 +72,6 @@
     </div>
 
     <div class="card" id="riskTools"></div>
-
-    <div class="card">
-      <div class="row" style="justify-content:space-between;">
-        <div>News & Events — <b id="newsSymbol"></b></div>
-        <div class="mini">Follow the selected asset</div>
-      </div>
-      <div id="newsTable"></div>
-    </div>
   </section>
 </div>
 

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -28,7 +28,7 @@ input.qty{width:78px;background:#0a1118;border:1px solid var(--border);color:var
 button{background:var(--btn);color:var(--text);border:1px solid var(--border);padding:6px 10px;border-radius:8px;cursor:pointer;transition:.15s}
 button:hover{background:var(--btn-hover)} button.accent{background:#12301f;border-color:#1e4230}
 button.bad{background:#2a1313;border-color:#3b1b1b}
-.right-col{display:grid;gap:16px}
+.left-col,.right-col{display:grid;gap:16px}
 .chart-wrap{height:260px;position:relative}
 canvas{width:100%;height:100%;background:#0a1017;border:1px solid var(--border);border-radius:8px}
 .statgrid{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin-top:8px}

--- a/src/index.html
+++ b/src/index.html
@@ -20,23 +20,33 @@
 </header>
 
 <div class="grid">
-  <section class="card">
-    <div class="row" style="justify-content:space-between;align-items:center;margin-bottom:8px;">
-      <div class="mini">10‑second days • After‑hours news drives tomorrow</div>
-      <div class="row">
-        <button id="startBtn" class="accent">▶ Start Day</button>
-        <button id="saveBtn">Save</button>
-        <button id="resetBtn" class="bad">Hard Reset</button>
+  <section class="left-col">
+    <div class="card">
+      <div class="row" style="justify-content:space-between;align-items:center;margin-bottom:8px;">
+        <div class="mini">10‑second days • After‑hours news drives tomorrow</div>
+        <div class="row">
+          <button id="startBtn" class="accent">▶ Start Day</button>
+          <button id="saveBtn">Save</button>
+          <button id="resetBtn" class="bad">Hard Reset</button>
+        </div>
       </div>
+      <table id="marketTable">
+        <thead>
+          <tr>
+            <th>Asset</th><th>Price</th><th>Δ</th><th>Analyst</th><th>Holdings</th><th>Value</th><th>Trade</th>
+          </tr>
+        </thead>
+        <tbody id="tbody"></tbody>
+      </table>
     </div>
-    <table id="marketTable">
-      <thead>
-        <tr>
-          <th>Asset</th><th>Price</th><th>Δ</th><th>Analyst</th><th>Holdings</th><th>Value</th><th>Trade</th>
-        </tr>
-      </thead>
-      <tbody id="tbody"></tbody>
-    </table>
+
+    <div class="card">
+      <div class="row" style="justify-content:space-between;">
+        <div>News & Events — <b id="newsSymbol"></b></div>
+        <div class="mini">Follow the selected asset</div>
+      </div>
+      <div id="newsTable"></div>
+    </div>
   </section>
 
   <section class="right-col">
@@ -62,14 +72,6 @@
     </div>
 
     <div class="card" id="riskTools"></div>
-
-    <div class="card">
-      <div class="row" style="justify-content:space-between;">
-        <div>News & Events — <b id="newsSymbol"></b></div>
-        <div class="mini">Follow the selected asset</div>
-      </div>
-      <div id="newsTable"></div>
-    </div>
   </section>
 </div>
 


### PR DESCRIPTION
## Summary
- Move the News & Events section into the left column so it appears below the asset list.
- Adjust grid layout CSS with a new `.left-col` class for vertical stacking.
- Update root and source index files to match the new layout.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e69ed9fd8832a862d5ad1369b0540