### PR TITLE
feat: add buy‑max and limit news panel height

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
 </header>
 
 <div class="grid">
-  <section class="left-col">
+  <section class="market-col">
     <div class="card">
       <div class="row" style="justify-content:space-between;align-items:center;margin-bottom:8px;">
         <div class="mini">10‑second days • After‑hours news drives tomorrow</div>
@@ -40,16 +40,9 @@
       </table>
     </div>
 
-    <div class="card">
-      <div class="row" style="justify-content:space-between;">
-        <div>News & Events — <b id="newsSymbol"></b></div>
-        <div class="mini">Follow the selected asset</div>
-      </div>
-      <div id="newsTable"></div>
-    </div>
   </section>
 
-  <section class="right-col">
+  <section class="mid-col">
     <div class="card">
       <div class="row" style="justify-content:space-between;">
         <div>Chart: <b id="chartTitle"></b></div>
@@ -62,6 +55,16 @@
       <div class="statgrid" id="chartStats"></div>
     </div>
 
+    <div class="card">
+      <div class="row" style="justify-content:space-between;">
+        <div>News & Events — <b id="newsSymbol"></b></div>
+        <div class="mini">Follow the selected asset</div>
+      </div>
+      <div id="newsScroll"><div id="newsTable"></div></div>
+    </div>
+  </section>
+
+  <section class="right-rail">
     <div class="card">
       <div class="row" style="justify-content:space-between;">
         <div>Asset Insight</div>

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -12,7 +12,7 @@ html,body{height:100%;margin:0;background:var(--bg);color:var(--text);
 .stats{display:flex;gap:10px;flex-wrap:wrap;align-items:center}
 .pill{background:var(--panel);border:1px solid var(--border);border-radius:999px;padding:6px 10px;display:flex;gap:8px;align-items:center}
 .kbd{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12px}
-.grid{display:grid;grid-template-columns:1.5fr 1fr;gap:16px;padding:16px;max-width:1500px;margin:0 auto}
+.grid{display:grid;grid-template-columns:2fr 1.5fr 1fr;gap:16px;padding:16px;max-width:1500px;margin:0 auto}
 @media (max-width:1100px){.grid{grid-template-columns:1fr}}
 .card{background:var(--panel);border:1px solid var(--border);border-radius:10px;padding:12px}
 .row{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
@@ -28,7 +28,10 @@ input.qty{width:78px;background:#0a1118;border:1px solid var(--border);color:var
 button{background:var(--btn);color:var(--text);border:1px solid var(--border);padding:6px 10px;border-radius:8px;cursor:pointer;transition:.15s}
 button:hover{background:var(--btn-hover)} button.accent{background:#12301f;border-color:#1e4230}
 button.bad{background:#2a1313;border-color:#3b1b1b}
-.left-col,.right-col{display:grid;gap:16px}
+.market-col,.mid-col,.right-rail{display:grid;gap:16px}
+.right-rail{min-width:260px;max-width:340px}
+#newsScroll{max-height:28rem;overflow:auto;padding-right:4px}
+@media (max-width:600px){#newsScroll{max-height:18rem}}
 .chart-wrap{height:260px;position:relative}
 canvas{width:100%;height:100%;background:#0a1017;border:1px solid var(--border);border-radius:8px}
 .statgrid{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin-top:8px}

--- a/src/index.html
+++ b/src/index.html
@@ -20,7 +20,7 @@
 </header>
 
 <div class="grid">
-  <section class="left-col">
+  <section class="market-col">
     <div class="card">
       <div class="row" style="justify-content:space-between;align-items:center;margin-bottom:8px;">
         <div class="mini">10‑second days • After‑hours news drives tomorrow</div>
@@ -40,16 +40,9 @@
       </table>
     </div>
 
-    <div class="card">
-      <div class="row" style="justify-content:space-between;">
-        <div>News & Events — <b id="newsSymbol"></b></div>
-        <div class="mini">Follow the selected asset</div>
-      </div>
-      <div id="newsTable"></div>
-    </div>
   </section>
 
-  <section class="right-col">
+  <section class="mid-col">
     <div class="card">
       <div class="row" style="justify-content:space-between;">
         <div>Chart: <b id="chartTitle"></b></div>
@@ -62,6 +55,16 @@
       <div class="statgrid" id="chartStats"></div>
     </div>
 
+    <div class="card">
+      <div class="row" style="justify-content:space-between;">
+        <div>News & Events — <b id="newsSymbol"></b></div>
+        <div class="mini">Follow the selected asset</div>
+      </div>
+      <div id="newsScroll"><div id="newsTable"></div></div>
+    </div>
+  </section>
+
+  <section class="right-rail">
     <div class="card">
       <div class="row" style="justify-content:space-between;">
         <div>Asset Insight</div>

--- a/src/js/ui/insight.js
+++ b/src/js/ui/insight.js
@@ -22,10 +22,12 @@ export function renderInsight(ctx){
     const posneg = (ev.mu + ev.demand) >= 0 ? 'pos' : 'neg';
     const who = ev.scope === 'global' ? 'GLOBAL' : a.sym;
     const days = ev.days ? ` • ${ev.days}d` : '';
+    const eff = `Bias ${ev.mu>=0?'+':''}${(ev.mu*10000).toFixed(0)}bp • Demand ${ev.demand>=0?'+':''}${(ev.demand*100).toFixed(1)}% • Vol ${ev.sigma>=0?'+':''}${(ev.sigma*100).toFixed(1)}%`;
+    const tip = `μ ${(ev.mu*10000).toFixed(0)}bp • σ ${(ev.sigma*100).toFixed(1)}% • D ${(ev.demand*100).toFixed(1)}%`;
     return `<div class="news-item">
       <b>${rec.when}</b> — <span>${who}: ${ev.title}</span>
       <span class="chip ${maj}">${ev.severity}</span>
-      <span class="chip ${posneg}">${ev.mu>=0?'+':''}${(ev.mu*10000).toFixed(0)}μ • ${ev.demand>=0?'+':''}${(ev.demand*100).toFixed(1)}% D</span>
+      <span class="chip ${posneg}" title="${tip}">${eff}</span>
       <span class="chip">${ev.type}${days}</span>
     </div>`;
   }).join('') || `<div class="news-item mini">No recent asset‑specific news.</div>`;

--- a/src/js/ui/newsAssets.js
+++ b/src/js/ui/newsAssets.js
@@ -12,13 +12,14 @@ export function renderAssetNewsTable(ctx){
   </tr></thead><tbody>`];
   for (const rec of list.slice(0,40)){
     const ev = rec.ev;
-    const eff = `${ev.mu>=0?'+':''}${(ev.mu*10000).toFixed(0)}μ • ${ev.demand>=0?'+':''}${(ev.demand*100).toFixed(1)}% D`;
+    const eff = `Bias ${ev.mu>=0?'+':''}${(ev.mu*10000).toFixed(0)}bp • Demand ${ev.demand>=0?'+':''}${(ev.demand*100).toFixed(1)}% • Vol ${ev.sigma>=0?'+':''}${(ev.sigma*100).toFixed(1)}%`;
+    const tip = `μ ${(ev.mu*10000).toFixed(0)}bp • σ ${(ev.sigma*100).toFixed(1)}% • D ${(ev.demand*100).toFixed(1)}%`;
     rows.push(`<tr>
       <td>${rec.when}</td>
       <td>${ev.scope==='global'?'GLOBAL: ':''}${ev.title}</td>
       <td>${ev.type}</td>
       <td>${ev.severity}</td>
-      <td>${eff}</td>
+      <td title="${tip}">${eff}</td>
       <td>${ev.timing || 'multi‑day'}</td>
     </tr>`);
   }

--- a/src/js/ui/table.js
+++ b/src/js/ui/table.js
@@ -15,6 +15,7 @@ export function buildMarketTable({ tbody, assets, state, onSelect, onBuy, onSell
         <div class="row">
           <input class="qty" type="number" min="1" step="1" value="10" id="q-${a.sym}" />
           <button class="accent" id="b-${a.sym}">Buy</button>
+          <button class="accent" id="bm-${a.sym}">Buy Max</button>
           <button class="bad" id="s-${a.sym}">Sell</button>
         </div>
       </td>`;
@@ -25,6 +26,18 @@ export function buildMarketTable({ tbody, assets, state, onSelect, onBuy, onSell
     });
     document.getElementById(`b-${a.sym}`).addEventListener('click', () => {
       const qty = parseInt(document.getElementById(`q-${a.sym}`).value || '0', 10);
+      onBuy(a.sym, qty);
+    });
+    document.getElementById(`bm-${a.sym}`).addEventListener('click', () => {
+      const price = a.price;
+      let qty = Math.floor((state.cash - state.minFee) / price);
+      if (qty < 0) qty = 0;
+      while (qty > 0) {
+        const fee = Math.max(state.minFee, qty * price * state.feeRate);
+        const cost = qty * price + fee;
+        if (cost <= state.cash) break;
+        qty--;
+      }
       onBuy(a.sym, qty);
     });
     document.getElementById(`s-${a.sym}`).addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Restructure layout into three-column grid and make News & Events panel scrollable to keep surrounding UI stable
- Simplify event effect wording and show human-friendly bias/demand/volatility values
- Add Buy‑Max shortcut in market table to auto-fill the largest affordable order

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ec07d1e1c832abe8e4cbdf7bae052