### PR TITLE
Add portfolio overview panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,6 +65,7 @@
   </section>
 
   <section class="right-rail">
+    <div class="card" id="portfolio"></div>
     <div class="card">
       <div class="row" style="justify-content:space-between;">
         <div>Asset Insight</div>

--- a/src/index.html
+++ b/src/index.html
@@ -65,6 +65,7 @@
   </section>
 
   <section class="right-rail">
+    <div class="card" id="portfolio"></div>
     <div class="card">
       <div class="row" style="justify-content:space-between;">
         <div>Asset Insight</div>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -16,6 +16,7 @@ import { renderInsight } from './ui/insight.js';
 import { renderAssetNewsTable } from './ui/newsAssets.js';
 import { showSummary } from './ui/modal.js';
 import { initRiskTools } from './ui/risktools.js';
+import { renderPortfolio } from './ui/portfolio.js';
 
 const toast = initToaster();
 const log = (msg)=>console.log(msg);
@@ -146,6 +147,7 @@ function renderAll() {
   drawChart(ctx);
   renderInsight(ctx);
   renderAssetNewsTable(ctx);
+  renderPortfolio(ctx);
 }
 
 // Initial render

--- a/src/js/ui/portfolio.js
+++ b/src/js/ui/portfolio.js
@@ -1,0 +1,36 @@
+import { fmt } from '../util/format.js';
+
+export function renderPortfolio(ctx){
+  const root = document.getElementById('portfolio');
+  if (!root) return;
+  const rows = [];
+  for (const a of ctx.assets){
+    const qty = ctx.state.positions[a.sym] || 0;
+    if (!qty) continue;
+    const avg = ctx.state.costBasis[a.sym]?.avg || 0;
+    const price = a.price;
+    const value = qty * price;
+    const pl = (price - avg) * qty;
+    rows.push(`<tr>
+      <td>${a.sym}</td>
+      <td>${qty.toLocaleString()}</td>
+      <td>${fmt(avg)}</td>
+      <td>${fmt(price)}</td>
+      <td class="${pl>=0?'up':'down'}">${fmt(pl)}</td>
+      <td>${fmt(value)}</td>
+    </tr>`);
+  }
+  if (!rows.length){
+    root.innerHTML = '<div class="mini">No holdings.</div>';
+    return;
+  }
+  root.innerHTML = `
+    <div class="row" style="justify-content:space-between;">
+      <div>Portfolio</div>
+      <div class="mini">Holdings overview</div>
+    </div>
+    <table>
+      <thead><tr><th>Sym</th><th>Qty</th><th>Avg Cost</th><th>Price</th><th>P/L</th><th>Value</th></tr></thead>
+      <tbody>${rows.join('')}</tbody>
+    </table>`;
+}


### PR DESCRIPTION
## Summary
- Add dedicated portfolio panel in right rail for consolidated holdings view.
- Hook up portfolio renderer to main app render loop.
- Implement holdings table renderer showing symbol, quantity, costs, and P/L.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ec4a6f8f4832a8d5cc132f88d336d