### PR TITLE
Add presets and grouping to Auto Risk Tools UI

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -61,6 +61,10 @@ canvas{width:100%;height:100%;background:#0a1017;border:1px solid var(--border);
 .chip.major{color:#ffcf8b;border-color:#6b4b1f}
 .chip.pos{color:#9ff0bf;border-color:#1f3a2b}
 .chip.neg{color:#ffb3b3;border-color:#3a2121}
+.chip-btn{font-size:10px;padding:2px 6px;border:1px solid var(--border);border-radius:999px;background:var(--btn);color:var(--muted);cursor:pointer}
+.chip-btn:hover{background:var(--btn-hover)}
+.section{margin-top:8px}
+.section-title{margin-bottom:4px;display:block}
 /* ===== Summary modal ===== */
 .overlay{position:fixed;inset:0;background:rgba(11,15,20,.8);display:none;align-items:center;justify-content:center;z-index:100}
 .modal{width:min(960px,94vw);background:#0f151d;border:1px solid var(--border);border-radius:12px;padding:14px;box-shadow:0 15px 50px rgba(0,0,0,.45)}

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -88,7 +88,7 @@ try {
 } catch { /* ignore */ }
 
 // Risk Tools UI
-initRiskTools(document.getElementById('riskTools'), ctx);
+initRiskTools(document.getElementById('riskTools'), ctx, toast);
 
 // Tick loop
 let interval = null;

--- a/src/js/ui/risktools.js
+++ b/src/js/ui/risktools.js
@@ -3,7 +3,7 @@ function loadSaved(){
 }
 function save(cfg){ try{ localStorage.setItem('ttm_risktools', JSON.stringify(cfg)); }catch{} }
 
-export function initRiskTools(root, ctx){
+export function initRiskTools(root, ctx, toast){
   // merge saved → ctx.state.riskTools
   const saved = loadSaved();
   if (saved) Object.assign(ctx.state.riskTools, saved);
@@ -15,69 +15,89 @@ export function initRiskTools(root, ctx){
       <div>Auto Risk Tools</div>
       <label class="mini"><input type="checkbox" id="rt-enabled"> Enabled</label>
     </div>
-    <div class="statgrid">
-      <div class="stat">
-        <div class="mini">Trailing stop (%)</div>
-        <input id="rt-trailing" type="number" min="0" step="0.01">
+    <div class="mini">Presets</div>
+    <div class="row preset-row">
+      <button class="chip-btn" id="rt-pre-con">Conservative</button>
+      <button class="chip-btn" id="rt-pre-bal">Balanced</button>
+      <button class="chip-btn" id="rt-pre-agg">Aggressive</button>
+    </div>
+    <div class="section">
+      <div class="mini section-title">Protection</div>
+      <div class="statgrid">
+        <div class="stat">
+          <div class="mini">Trailing stop (%)</div>
+          <input id="rt-trailing" type="number" min="0" step="0.01">
+        </div>
+        <div class="stat">
+          <div class="mini">Hard stop (%)</div>
+          <input id="rt-hard" type="number" min="0" step="0.01">
+        </div>
+        <div class="stat">
+          <div class="mini">Stop sell fraction (0–1)</div>
+          <input id="rt-stopfrac" type="number" min="0.05" max="1" step="0.05">
+        </div>
       </div>
-      <div class="stat">
-        <div class="mini">Hard stop (%)</div>
-        <input id="rt-hard" type="number" min="0" step="0.01">
+    </div>
+    <div class="section">
+      <div class="mini section-title">Profit taking</div>
+      <div class="statgrid">
+        <div class="stat">
+          <div class="mini">TP1 threshold (%)</div>
+          <input id="rt-tp1" type="number" min="0.05" step="0.05">
+        </div>
+        <div class="stat">
+          <div class="mini">TP1 sell fraction (0–1)</div>
+          <input id="rt-tp1f" type="number" min="0.05" max="1" step="0.05">
+        </div>
+        <div class="stat">
+          <div class="mini">TP2 threshold (%)</div>
+          <input id="rt-tp2" type="number" min="0.05" step="0.05">
+        </div>
+        <div class="stat">
+          <div class="mini">TP2 sell fraction (0–1)</div>
+          <input id="rt-tp2f" type="number" min="0.05" max="1" step="0.05">
+        </div>
+        <div class="stat">
+          <div class="mini">TP3 threshold (%)</div>
+          <input id="rt-tp3" type="number" min="0.05" step="0.05">
+        </div>
+        <div class="stat">
+          <div class="mini">TP3 sell fraction (0–1)</div>
+          <input id="rt-tp3f" type="number" min="0.05" max="1" step="0.05">
+        </div>
       </div>
-      <div class="stat">
-        <div class="mini">Stop sell fraction (0–1)</div>
-        <input id="rt-stopfrac" type="number" min="0.05" max="1" step="0.05">
-      </div>
-      <div class="stat">
-        <div class="mini">Position cap (% of net)</div>
-        <input id="rt-cap" type="number" min="0.05" max="1" step="0.05">
-      </div>
-
-      <div class="stat">
-        <div class="mini">TP1 threshold (%)</div>
-        <input id="rt-tp1" type="number" min="0.05" step="0.05">
-      </div>
-      <div class="stat">
-        <div class="mini">TP1 sell fraction (0–1)</div>
-        <input id="rt-tp1f" type="number" min="0.05" max="1" step="0.05">
-      </div>
-
-      <div class="stat">
-        <div class="mini">TP2 threshold (%)</div>
-        <input id="rt-tp2" type="number" min="0.05" step="0.05">
-      </div>
-      <div class="stat">
-        <div class="mini">TP2 sell fraction (0–1)</div>
-        <input id="rt-tp2f" type="number" min="0.05" max="1" step="0.05">
-      </div>
-
-      <div class="stat">
-        <div class="mini">TP3 threshold (%)</div>
-        <input id="rt-tp3" type="number" min="0.05" step="0.05">
-      </div>
-      <div class="stat">
-        <div class="mini">TP3 sell fraction (0–1)</div>
-        <input id="rt-tp3f" type="number" min="0.05" max="1" step="0.05">
+    </div>
+    <div class="section">
+      <div class="mini section-title">Exposure cap</div>
+      <div class="statgrid">
+        <div class="stat">
+          <div class="mini">Position cap (% of net)</div>
+          <input id="rt-cap" type="number" min="0.05" max="1" step="0.05">
+        </div>
       </div>
     </div>
     <div class="row" style="justify-content:flex-end;margin-top:8px;">
+      <span class="mini" id="rt-status" style="flex:1"></span>
       <button id="rt-apply" class="accent">Apply</button>
     </div>
   `;
 
-  // hydrate inputs
   const byId = id => /** @type {HTMLInputElement} */(document.getElementById(id));
-  byId('rt-enabled').checked = !!cfg.enabled;
-  byId('rt-trailing').value = String((cfg.trailing||0.12).toFixed(2));
-  byId('rt-hard').value     = String((cfg.hardStop||0.18).toFixed(2));
-  byId('rt-stopfrac').value = String((cfg.stopSellFrac||1.0).toFixed(2));
-  byId('rt-cap').value      = String((cfg.posCap||0.35).toFixed(2));
-  byId('rt-tp1').value      = String((cfg.tp1||0.20).toFixed(2));
-  byId('rt-tp1f').value     = String((cfg.tp1Frac||0.25).toFixed(2));
-  byId('rt-tp2').value      = String((cfg.tp2||0.40).toFixed(2));
-  byId('rt-tp2f').value     = String((cfg.tp2Frac||0.25).toFixed(2));
-  byId('rt-tp3').value      = String((cfg.tp3||0.80).toFixed(2));
-  byId('rt-tp3f').value     = String((cfg.tp3Frac||0.50).toFixed(2));
+
+  function hydrate(){
+    byId('rt-enabled').checked = !!cfg.enabled;
+    byId('rt-trailing').value = String((cfg.trailing||0.12).toFixed(2));
+    byId('rt-hard').value     = String((cfg.hardStop||0.18).toFixed(2));
+    byId('rt-stopfrac').value = String((cfg.stopSellFrac||1.0).toFixed(2));
+    byId('rt-cap').value      = String((cfg.posCap||0.35).toFixed(2));
+    byId('rt-tp1').value      = String((cfg.tp1||0.20).toFixed(2));
+    byId('rt-tp1f').value     = String((cfg.tp1Frac||0.25).toFixed(2));
+    byId('rt-tp2').value      = String((cfg.tp2||0.40).toFixed(2));
+    byId('rt-tp2f').value     = String((cfg.tp2Frac||0.25).toFixed(2));
+    byId('rt-tp3').value      = String((cfg.tp3||0.80).toFixed(2));
+    byId('rt-tp3f').value     = String((cfg.tp3Frac||0.50).toFixed(2));
+  }
+  hydrate();
 
   function apply(){
     cfg.enabled = byId('rt-enabled').checked;
@@ -92,10 +112,33 @@ export function initRiskTools(root, ctx){
     cfg.tp3 = Math.max(0, parseFloat(byId('rt-tp3').value)||0.8);
     cfg.tp3Frac = Math.min(1, Math.max(0.05, parseFloat(byId('rt-tp3f').value)||0.5));
     save(cfg);
+    if (toast) {
+      toast('Saved', 'good');
+      const status = document.getElementById('rt-status');
+      if (status) {
+        status.textContent = 'Saved';
+        setTimeout(() => { status.textContent = ''; }, 1200);
+      }
+    }
   }
   document.getElementById('rt-apply').addEventListener('click', apply);
 
   // Save immediately on toggle/enter
   ['rt-enabled','rt-trailing','rt-hard','rt-stopfrac','rt-cap','rt-tp1','rt-tp1f','rt-tp2','rt-tp2f','rt-tp3','rt-tp3f']
     .forEach(id => document.getElementById(id).addEventListener('change', apply));
+
+  // Presets
+  const presets = {
+    con:{ trailing:0.08, hardStop:0.12, stopSellFrac:1, posCap:0.25, tp1:0.15, tp1Frac:0.25, tp2:0.30, tp2Frac:0.25, tp3:0.60, tp3Frac:0.50 },
+    bal:{ trailing:0.12, hardStop:0.18, stopSellFrac:1, posCap:0.35, tp1:0.20, tp1Frac:0.25, tp2:0.40, tp2Frac:0.25, tp3:0.80, tp3Frac:0.50 },
+    agg:{ trailing:0.20, hardStop:0.25, stopSellFrac:1, posCap:0.50, tp1:0.25, tp1Frac:0.30, tp2:0.50, tp2Frac:0.30, tp3:1.00, tp3Frac:0.50 }
+  };
+  function setPreset(p){
+    Object.assign(cfg, presets[p]);
+    hydrate();
+    apply();
+  }
+  document.getElementById('rt-pre-con').addEventListener('click', () => setPreset('con'));
+  document.getElementById('rt-pre-bal').addEventListener('click', () => setPreset('bal'));
+  document.getElementById('rt-pre-agg').addEventListener('click', () => setPreset('agg'));
 }


### PR DESCRIPTION
## Summary
- Group Auto Risk controls into protection, profit taking, and exposure sections
- Add Conservative/Balanced/Aggressive preset chips with toast feedback
- Style chip buttons and section spacing; wire risk tools to toast

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ec6bbdfbc832aaa246373eb072e2d