### PR TITLE
Implement margin liquidation checks

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -103,6 +103,16 @@ function start() {
   renderAll();
   interval = setInterval(() => {
     stepTick(ctx, CFG, rng, { log, toast });
+    if (ctx.gameOver) {
+      clearInterval(interval); interval = null;
+      renderAll();
+      showGameOver(() => {
+        document.getElementById('overlay').style.display = 'none';
+        localStorage.removeItem('ttm_save');
+        location.reload();
+      });
+      return;
+    }
     // Auto‑Risk after price update
     evaluateRisk(ctx, { log, toast });
     renderAll();
@@ -115,7 +125,7 @@ function start() {
       enqueueAfterHours(ctx, CFG, rng, { log, toast });
       renderAll();
 
-      if (summary.gameOver) {
+      if (summary.gameOver || ctx.gameOver) {
         showGameOver(() => {
           document.getElementById('overlay').style.display = 'none';
           localStorage.removeItem('ttm_save');

--- a/src/js/core/cycle.js
+++ b/src/js/core/cycle.js
@@ -1,6 +1,7 @@
 import { applyOvernightOutlook, applyOpeningGaps, updatePrices, riskDrift, demandDrift, computeAnalyst } from './priceModel.js';
 import { randomEvent, randomSupplyEvent, pushAssetNews } from './events.js';
 import { CFG } from '../config.js';
+import { checkMargin } from './trading.js';
 
 export function startDay(ctx, cfg=CFG, hooks){
   ctx.day.idx += 1; ctx.day.active = true; ctx.day.ticksLeft = cfg.DAY_TICKS;
@@ -38,6 +39,7 @@ export function stepTick(ctx, cfg, rng, hooks){
   }
 
   updatePrices(ctx, rng);
+  checkMargin(ctx, hooks);
   ctx.market.activeEvents = ctx.market.activeEvents.map(ev => ({...ev, t:(ev.t||10)-1})).filter(ev => ev.t > 0);
 
   ctx.day.ticksLeft--;

--- a/src/js/core/state.js
+++ b/src/js/core/state.js
@@ -62,6 +62,6 @@ export function createInitialState(assetDefs){
   };
 
   // Misc runtime trackers
-  const ctx = { assets, state, market, day, newsByAsset, riskTrack: {} };
+  const ctx = { assets, state, market, day, newsByAsset, riskTrack: {}, gameOver:false };
   return ctx;
 }


### PR DESCRIPTION
## Summary
- Add margin liquidation routine to close underwater leveraged positions and flag game over when equity wipes out or 100x lots liquidate
- Integrate liquidation checks into daily tick and mid-day game over handling
- Expand margin tests to cover liquidation and high-leverage failure cases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ed2b12f7c832a89dd47e69f1d0659