### PR TITLE
Add insider tip workflow with leverage bias and cooldown

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "description": "Trading simulation game framework with HTML, CSS, and JavaScript.",
   "type": "module",
   "scripts": {
-    "test": "node src/js/test/engine.spec.js && node src/js/test/cycle.spec.js && node src/js/test/margin.spec.js"
+    "test": "node src/js/test/engine.spec.js && node src/js/test/cycle.spec.js && node src/js/test/margin.spec.js && node src/js/test/insider.spec.js"
   }
 }

--- a/src/js/core/events.js
+++ b/src/js/core/events.js
@@ -18,7 +18,21 @@ export const EVENT_POOL = [
 ];
 
 export function randomEvent(ctx, rng, newsLevel=0){
-  const pool = EVENT_POOL.filter(ev => !ev.requires || ev.requires.every(id => ctx.state.upgrades[id]));
+  let pool = EVENT_POOL.filter(ev => !ev.requires || ev.requires.every(id => ctx.state.upgrades[id]));
+  pool = pool.map(ev => {
+    if (ev.sym === '{TIP_SYM}' && ctx.state.insiderTip) {
+      return { ...ev, sym: ctx.state.insiderTip.sym };
+    }
+    return ev;
+  });
+  if (ctx.state.insiderTip && ctx.state.insiderTip.daysLeft > 0) {
+    const sym = ctx.state.insiderTip.sym;
+    const extras = [];
+    for (const ev of pool) {
+      if (ev.sym === sym && ev.mu > 0) extras.push(ev);
+    }
+    pool = pool.concat(extras);
+  }
   const base = pool.length ? pool : EVENT_POOL;
   const ev = { ...base[Math.floor(rng() * base.length)] };
   const nScale = 1 + newsLevel * 0.05;

--- a/src/js/core/priceModel.js
+++ b/src/js/core/priceModel.js
@@ -67,8 +67,15 @@ export function applyOvernightOutlook(ctx){
     if (a.streak>3 && a.price>a.fair){ reversion = -CFG.STREAK_REVERSION*(a.streak-3) * CFG.DAY_TICKS; bias="reversion"; }
     if (a.streak<-3 && a.price<a.fair){ reversion = CFG.STREAK_REVERSION*(-a.streak-3) * CFG.DAY_TICKS; bias="reversion"; }
 
-    const mu    = gMu + evMu + valuation + streakMR + demandTerm + reversion;
-    const sigma = clamp(0.006 + evVol*0.6 + Math.abs(gDem)*0.15, 0.006, 0.10);
+    let mu    = gMu + evMu + valuation + streakMR + demandTerm + reversion;
+    let sigma = clamp(0.006 + evVol*0.6 + Math.abs(gDem)*0.15, 0.006, 0.10);
+    if (ctx.state.insiderTip && ctx.state.insiderTip.daysLeft > 0 && ctx.state.insiderTip.sym === a.sym) {
+      const [muMin, muMax] = CFG.INSIDER_MU_RANGE;
+      const [sigMin, sigMax] = CFG.INSIDER_SIGMA_RANGE;
+      mu += muMin + Math.random() * (muMax - muMin);
+      sigma += sigMin + Math.random() * (sigMax - sigMin);
+      sigma = clamp(sigma, 0.006, 0.12);
+    }
     const gap   = clamp( (gMu*CFG.DAY_TICKS*0.35) + (evMu*CFG.DAY_TICKS*0.75) + (evDem*0.55), -CFG.OPEN_GAP_CAP, CFG.OPEN_GAP_CAP);
 
     a.daySigma = sigma;

--- a/src/js/core/state.js
+++ b/src/js/core/state.js
@@ -43,7 +43,8 @@ export function createInitialState(assetDefs){
     upgradePurchases: { insider:0, leverage:0, debt_rate:0, options:0, crypto:0 },
     cooldowns: { insider:0 },
     ui: { lastLev: {} },
-    marginPositions: []
+    marginPositions: [],
+    insiderTip: null
   };
 
   const market = {

--- a/src/js/test/insider.spec.js
+++ b/src/js/test/insider.spec.js
@@ -1,0 +1,22 @@
+import assert from 'assert';
+import { CFG, ASSET_DEFS } from '../config.js';
+import { createInitialState } from '../core/state.js';
+import { startDay, endDay } from '../core/cycle.js';
+
+(function testInsiderWindow(){
+  const cfg = { ...CFG, INTRADAY_EVENT_P:0, AH_EVENT_P:0, AH_SUPPLY_EVENT_P:0 };
+  const ctx = createInitialState(ASSET_DEFS.slice(0,1));
+  ctx.state.insiderTip = { sym: ctx.assets[0].sym, daysLeft: CFG.INSIDER_DAYS };
+  ctx.state.cooldowns.insider = CFG.INSIDER_COOLDOWN_DAYS;
+  const initialCd = ctx.state.cooldowns.insider;
+  startDay(ctx, cfg);
+  assert.strictEqual(ctx.state.upgrades.insider, true, 'insider active at start');
+  endDay(ctx, cfg);
+  assert.strictEqual(ctx.state.cooldowns.insider, initialCd - 1, 'cooldown decremented');
+  for(let d=1; d<CFG.INSIDER_DAYS; d++){
+    startDay(ctx, cfg); endDay(ctx, cfg);
+  }
+  startDay(ctx, cfg);
+  assert.strictEqual(ctx.state.upgrades.insider, false, 'insider inactive after days');
+  endDay(ctx, cfg);
+})();


### PR DESCRIPTION
## Summary
- Implement insider tip upgrade with symbol selection and cooldown
- Bias selected asset's outlook and event weighting while tip active
- Track tip lifecycle in state and add regression tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ed55c32c4832a8d2d8b618af82c03