### PR TITLE
Add options trading system with pricing and portfolio support

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "description": "Trading simulation game framework with HTML, CSS, and JavaScript.",
   "type": "module",
   "scripts": {
-    "test": "node src/js/test/engine.spec.js && node src/js/test/cycle.spec.js && node src/js/test/margin.spec.js && node src/js/test/insider.spec.js"
+    "test": "node src/js/test/engine.spec.js && node src/js/test/cycle.spec.js && node src/js/test/margin.spec.js && node src/js/test/insider.spec.js && node src/js/test/options.spec.js"
   }
 }

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -7,6 +7,7 @@ import { createInitialState } from './core/state.js';
 import { startDay, stepTick, endDay, enqueueAfterHours } from './core/cycle.js';
 import { computeAnalyst } from './core/priceModel.js';
 import { buy, sell } from './core/trading.js';
+import { buyOption } from './core/options.js';
 import { evaluateRisk } from './core/risk.js';
 
 import { initToaster } from './ui/toast.js';
@@ -34,19 +35,20 @@ document.getElementById('chartTitle').textContent =
   `${ctx.selected} — ${ctx.assets.find(a => a.sym === ctx.selected).name}`;
 
 // Build market table with module trading
-buildMarketTable({
-  tbody: document.getElementById('tbody'),
-  assets: ctx.assets,
-  state: ctx.state,
-  onSelect: (sym) => {
-    ctx.selected = sym;
-    document.getElementById('chartTitle').textContent =
-      `${sym} — ${ctx.assets.find(a => a.sym === sym).name}`;
-    renderAll();
-  },
-  onBuy: (sym, qty, lev) => { buy(ctx, sym, qty, { leverage: lev, log }); renderAll(); },
-  onSell: (sym, qty, lev) => { sell(ctx, sym, qty, { leverage: lev, log }); renderAll(); }
-});
+  buildMarketTable({
+    tbody: document.getElementById('tbody'),
+    assets: ctx.assets,
+    state: ctx.state,
+    onSelect: (sym) => {
+      ctx.selected = sym;
+      document.getElementById('chartTitle').textContent =
+        `${sym} — ${ctx.assets.find(a => a.sym === sym).name}`;
+      renderAll();
+    },
+    onBuy: (sym, qty, lev) => { buy(ctx, sym, qty, { leverage: lev, log }); renderAll(); },
+    onSell: (sym, qty, lev) => { sell(ctx, sym, qty, { leverage: lev, log }); renderAll(); },
+    onOption: (sym, opt) => { buyOption(ctx, sym, opt.type, opt.strike, opt.dte, opt.qty, { log }); renderAll(); }
+  });
 
 // Chart type toggle
 ctx.chartMode = 'line';

--- a/src/js/core/cycle.js
+++ b/src/js/core/cycle.js
@@ -2,6 +2,7 @@ import { applyOvernightOutlook, applyOpeningGaps, updatePrices, riskDrift, deman
 import { randomEvent, randomSupplyEvent, pushAssetNews } from './events.js';
 import { CFG } from '../config.js';
 import { checkMargin } from './trading.js';
+import { updateOptions } from './options.js';
 
 export function startDay(ctx, cfg=CFG, hooks){
   if (ctx.state.insiderTip && ctx.state.insiderTip.daysLeft > 0) {
@@ -52,6 +53,7 @@ export function stepTick(ctx, cfg, rng, hooks){
   }
 
   updatePrices(ctx, rng);
+  updateOptions(ctx, cfg);
   checkMargin(ctx, hooks);
   ctx.market.activeEvents = ctx.market.activeEvents.map(ev => ({...ev, t:(ev.t||10)-1})).filter(ev => ev.t > 0);
 

--- a/src/js/core/options.js
+++ b/src/js/core/options.js
@@ -1,0 +1,78 @@
+import { clamp } from '../util/math.js';
+import { CFG } from '../config.js';
+
+const DAYS_PER_YEAR = 252;
+
+function erf(x){
+  const sign = x < 0 ? -1 : 1;
+  x = Math.abs(x);
+  const a1 = 0.254829592,
+        a2 = -0.284496736,
+        a3 = 1.421413741,
+        a4 = -1.453152027,
+        a5 = 1.061405429,
+        p = 0.3275911;
+  const t = 1 / (1 + p * x);
+  const y = 1 - ((((a5*t + a4)*t + a3)*t + a2)*t + a1)*t*Math.exp(-x*x);
+  return sign * y;
+}
+function normCdf(x){ return 0.5 * (1 + erf(x / Math.sqrt(2))); }
+
+function priceOptionInternal(S, K, T, sigma, type){
+  const vol = clamp(sigma, CFG.OPTIONS_MIN_IV, CFG.OPTIONS_MAX_IV);
+  if (T <= 0) {
+    return type === 'call' ? Math.max(0, S - K) : Math.max(0, K - S);
+  }
+  const sqrtT = Math.sqrt(T);
+  const d1 = (Math.log(S / K) + 0.5 * vol * vol * T) / (vol * sqrtT);
+  const d2 = d1 - vol * sqrtT;
+  if (type === 'call') {
+    return S * normCdf(d1) - K * normCdf(d2);
+  } else {
+    return K * normCdf(-d2) - S * normCdf(-d1);
+  }
+}
+
+export function buyOption(ctx, sym, type, strike, dte, qty, opts={}){
+  qty = Math.max(1, Math.floor(qty));
+  const a = ctx.assets.find(x => x.sym === sym);
+  if (!a) return;
+  const sigma = a.daySigma || a.sigma;
+  const premium = priceOptionInternal(a.price, strike, dte / DAYS_PER_YEAR, sigma, type);
+  const cost = premium * qty;
+  const fee = Math.max(ctx.state.minFee, cost * ctx.state.feeRate);
+  const total = cost + fee;
+  if (ctx.state.cash >= total) ctx.state.cash -= total;
+  else { const short = total - ctx.state.cash; ctx.state.cash = 0; ctx.state.debt += short; }
+  ctx.state.optionPositions.push({
+    id: `${sym}-${Date.now()}-${Math.random().toString(36).slice(2,8)}`,
+    sym, type, strike, dte, qty, premium, mark: premium
+  });
+  ctx.day.feesPaid += fee;
+  opts.log?.(`Bought ${qty} ${type} ${sym} ${strike} (${dte}d) premium $${premium.toFixed(2)}`);
+}
+
+export function updateOptions(ctx, cfg=CFG){
+  for (let i = ctx.state.optionPositions.length - 1; i >= 0; i--) {
+    const p = ctx.state.optionPositions[i];
+    const a = ctx.assets.find(x => x.sym === p.sym);
+    if (!a) { ctx.state.optionPositions.splice(i,1); continue; }
+    p.dte -= 1 / cfg.DAY_TICKS;
+    if (p.dte <= 1e-6) {
+      const intrinsic = p.type === 'call' ? Math.max(0, a.price - p.strike) : Math.max(0, p.strike - a.price);
+      const value = intrinsic * p.qty;
+      ctx.state.cash += value;
+      const realized = (intrinsic - p.premium) * p.qty;
+      ctx.state.realizedPnL += realized;
+      ctx.day.realized += realized;
+      ctx.state.optionPositions.splice(i,1);
+      continue;
+    }
+    const sigma = a.daySigma || a.sigma;
+    p.mark = priceOptionInternal(a.price, p.strike, p.dte / DAYS_PER_YEAR, sigma, p.type);
+  }
+}
+
+export function priceOption(S, K, T, sigma, type){
+  return priceOptionInternal(S, K, T, sigma, type);
+}

--- a/src/js/core/state.js
+++ b/src/js/core/state.js
@@ -44,6 +44,7 @@ export function createInitialState(assetDefs){
     cooldowns: { insider:0 },
     ui: { lastLev: {} },
     marginPositions: [],
+    optionPositions: [],
     insiderTip: null
   };
 

--- a/src/js/test/options.spec.js
+++ b/src/js/test/options.spec.js
@@ -1,0 +1,59 @@
+import { strict as assert } from 'assert';
+import { createInitialState } from '../core/state.js';
+import { CFG, ASSET_DEFS } from '../config.js';
+import { buyOption, updateOptions } from '../core/options.js';
+
+function setup(){
+  const defs = [ { ...ASSET_DEFS[0] } ];
+  defs[0].price = 100; // easier baseline
+  return createInitialState(defs);
+}
+
+// Call option increases with price
+{
+  const ctx = setup();
+  const sym = ctx.assets[0].sym;
+  buyOption(ctx, sym, 'call', 100, 30, 1);
+  const mark0 = ctx.state.optionPositions[0].mark;
+  ctx.assets[0].price = 120;
+  updateOptions(ctx, CFG);
+  const mark1 = ctx.state.optionPositions[0].mark;
+  assert(mark1 > mark0, 'Call mark should rise with underlying');
+}
+
+// Put option increases when price falls
+{
+  const ctx = setup();
+  const sym = ctx.assets[0].sym;
+  buyOption(ctx, sym, 'put', 100, 30, 1);
+  const mark0 = ctx.state.optionPositions[0].mark;
+  ctx.assets[0].price = 80;
+  updateOptions(ctx, CFG);
+  const mark1 = ctx.state.optionPositions[0].mark;
+  assert(mark1 > mark0, 'Put mark should rise when price falls');
+}
+
+// Theta decay
+{
+  const ctx = setup();
+  const sym = ctx.assets[0].sym;
+  buyOption(ctx, sym, 'call', 100, 10, 1);
+  const mark0 = ctx.state.optionPositions[0].mark;
+  for(let i=0;i<CFG.DAY_TICKS;i++) updateOptions(ctx, CFG);
+  const mark1 = ctx.state.optionPositions[0].mark;
+  assert(mark1 < mark0, 'Option mark should decay over time');
+}
+
+// Expiry settlement
+{
+  const ctx = setup();
+  const sym = ctx.assets[0].sym;
+  buyOption(ctx, sym, 'call', 90, 1, 1);
+  const premium = ctx.state.optionPositions[0].premium;
+  ctx.assets[0].price = 110;
+  for(let i=0;i<CFG.DAY_TICKS;i++) updateOptions(ctx, CFG);
+  assert.equal(ctx.state.optionPositions.length, 0, 'Position should expire');
+  assert(ctx.state.cash > CFG.START_CASH - premium, 'Intrinsic value credited');
+}
+
+console.log('options.spec passed');

--- a/src/js/ui/options.js
+++ b/src/js/ui/options.js
@@ -1,0 +1,14 @@
+import { CFG } from '../config.js';
+
+export function openOptionsDialog(asset, onConfirm){
+  const typeRaw = prompt('Option type (call/put)', 'call');
+  if (!typeRaw) return;
+  const type = typeRaw.toLowerCase() === 'put' ? 'put' : 'call';
+  const strike = parseFloat(prompt('Strike', asset.price.toFixed(2)));
+  if (isNaN(strike)) return;
+  const dte = parseInt(prompt(`DTE (${CFG.OPTIONS_DEFAULT_DTE.join('/')})`, String(CFG.OPTIONS_DEFAULT_DTE[0])), 10);
+  if (!dte || dte <= 0) return;
+  const qty = parseInt(prompt('Quantity', '1'), 10);
+  if (!qty || qty <= 0) return;
+  onConfirm({ type, strike, dte, qty });
+}

--- a/src/js/ui/portfolio.js
+++ b/src/js/ui/portfolio.js
@@ -48,5 +48,22 @@ export function renderPortfolio(ctx){
       ${mRows.length ? `<table><thead><tr><th>Sym</th><th>Qty</th><th>Entry</th><th>Lev</th><th>Liq Price</th><th>Maint</th><th>P/L</th><th>Value</th></tr></thead><tbody>${mRows.join('')}</tbody></table>` : '<div class="mini">No margin positions.</div>'}
     </div>`):'';
 
-  root.innerHTML = holdSection + marginSection;
+  const oRows = [];
+  for (const opt of ctx.state.optionPositions) {
+    const a = ctx.assets.find(x => x.sym === opt.sym);
+    if (!a) continue;
+    const pl = (opt.mark - opt.premium) * opt.qty;
+    const val = opt.mark * opt.qty;
+    oRows.push(`<tr><td>${opt.sym}</td><td>${opt.type}</td><td>${fmt(opt.strike)}</td><td>${Math.max(0,Math.round(opt.dte))}</td><td>${opt.qty}</td><td>${fmt(opt.premium)}</td><td>${fmt(opt.mark)}</td><td class="${pl>=0?'up':'down'}">${fmt(pl)}</td><td>${fmt(val)}</td></tr>`);
+  }
+  const optionsSection = (ctx.state.upgrades.options || oRows.length) ? (`
+    <div class="section">
+      <div class="row" style="justify-content:space-between;">
+        <div>Options</div>
+        <div class="mini">Options positions</div>
+      </div>
+      ${oRows.length ? `<table><thead><tr><th>Sym</th><th>Type</th><th>Strike</th><th>DTE</th><th>Qty</th><th>Premium</th><th>Mark</th><th>P/L</th><th>Value</th></tr></thead><tbody>${oRows.join('')}</tbody></table>` : '<div class="mini">No options positions.</div>'}
+    </div>`):'';
+
+  root.innerHTML = holdSection + marginSection + optionsSection;
 }

--- a/src/js/ui/table.js
+++ b/src/js/ui/table.js
@@ -1,7 +1,8 @@
 import { fmt, pct } from '../util/format.js';
 import { CFG } from '../config.js';
+import { openOptionsDialog } from './options.js';
 
-export function buildMarketTable({ tbody, assets, state, onSelect, onBuy, onSell }){
+export function buildMarketTable({ tbody, assets, state, onSelect, onBuy, onSell, onOption }){
   tbody.innerHTML = '';
   for (const a of assets){
     const tr = document.createElement('tr'); tr.dataset.sym = a.sym;
@@ -19,6 +20,7 @@ export function buildMarketTable({ tbody, assets, state, onSelect, onBuy, onSell
           <button class="accent" id="b-${a.sym}">Buy</button>
           <button class="accent" id="bm-${a.sym}">Buy Max</button>
           <button class="bad" id="s-${a.sym}">Sell</button>
+          ${state.upgrades.options ? `<button class="accent" id="o-${a.sym}">Opt</button>` : ''}
         </div>
       </td>`;
     tbody.appendChild(tr);
@@ -62,6 +64,11 @@ export function buildMarketTable({ tbody, assets, state, onSelect, onBuy, onSell
       const lev = state.upgrades.leverage>0 ? parseInt(document.getElementById(`lv-${a.sym}`).value,10) : 1;
       onSell(a.sym, qty, lev);
     });
+    if (state.upgrades.options) {
+      document.getElementById(`o-${a.sym}`).addEventListener('click', () => {
+        openOptionsDialog(a, (opt) => { onOption && onOption(a.sym, opt); });
+      });
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Implement simplified Black-Scholes pricing module and option lifecycle management.
- Add Options button to market table with prompt-based dialog for creating call/put positions.
- Display open option positions in the portfolio and update marks each tick.
- Include unit tests validating option pricing behavior and expiration.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ed7ad5d9c832aae94a03b3b8c7aff