### PR TITLE
feat: add crypto market and moon dynamics

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "description": "Trading simulation game framework with HTML, CSS, and JavaScript.",
   "type": "module",
   "scripts": {
-    "test": "node src/js/test/engine.spec.js && node src/js/test/cycle.spec.js && node src/js/test/margin.spec.js && node src/js/test/insider.spec.js && node src/js/test/options.spec.js"
+    "test": "node src/js/test/engine.spec.js && node src/js/test/cycle.spec.js && node src/js/test/margin.spec.js && node src/js/test/insider.spec.js && node src/js/test/options.spec.js && node src/js/test/crypto.spec.js"
   }
 }

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -18,6 +18,7 @@ html,body{height:100%;margin:0;background:var(--bg);color:var(--text);
 .row{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
 .mini{font-size:12px;color:var(--muted)}
 .tag{font-size:11px;padding:2px 6px;border:1px solid var(--border);border-radius:999px;color:var(--muted)}
+ .tabs{margin-bottom:8px}
 table{width:100%;border-collapse:separate;border-spacing:0}
 thead th{position:sticky;top:0;background:var(--table);color:var(--muted);text-align:left;padding:8px;border-bottom:1px solid var(--border)}
 tbody td{padding:8px;border-bottom:1px dashed rgba(255,255,255,.06);vertical-align:middle}

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -65,5 +65,8 @@ export const ASSET_DEFS = [
   {sym:"SOL", name:"Solar Sail Conglom.",     sector:"Aero",     price:51,  mu:0.0009, sigma:0.028, k:0.0010, supply:1_700_000},
   {sym:"NNC", name:"NeuroNet Cloud",          sector:"AI",       price:93,  mu:0.0013, sigma:0.032, k:0.0009, supply:900_000},
   {sym:"GAT", name:"Gate Array Prototypes",   sector:"Exotic",   price:24,  mu:0.0016, sigma:0.040, k:0.0015, supply:3_400_000},
-  {sym:"CYB", name:"CyberDefense Mesh",       sector:"Security", price:79,  mu:0.0010, sigma:0.023, k:0.0011, supply:1_400_000}
+  {sym:"CYB", name:"CyberDefense Mesh",       sector:"Security", price:79,  mu:0.0010, sigma:0.023, k:0.0011, supply:1_400_000},
+  {sym:"BTC", name:"Bitcoin",                 sector:"Crypto",   price:30000, mu:0.0015, sigma:0.050, k:0.0020, supply:19_000_000, isCrypto:true},
+  {sym:"ETH", name:"Ethereum",                sector:"Crypto",   price:2000,  mu:0.0018, sigma:0.060, k:0.0022, supply:120_000_000, isCrypto:true},
+  {sym:"MOON",name:"Moon Coin",               sector:"Crypto",   price:1,     mu:0.0010, sigma:0.080, k:0.0025, supply:1_000_000_000, isCrypto:true}
 ];

--- a/src/js/core/events.js
+++ b/src/js/core/events.js
@@ -14,6 +14,8 @@ export const EVENT_POOL = [
   {scope:"asset", sym:"SOL",  title:"Sail tear recall",  type:"recall",   mu:-0.0011, sigma:+0.012, demand:-0.10, days:2, severity:"major", blurb:"Retrofit program announced."},
   {scope:'global', title:'Options expiration gamma squeeze', type:'options_flow', mu:+0.0014, sigma:+0.012, demand:+0.06, days:2, severity:'major', blurb:'Dealer gamma flip fuels upside.', requires:['options']},
   {scope:'asset', sym:'BTC', title:'New exchange listing', type:'crypto_flow', mu:+0.0018, sigma:+0.016, demand:+0.09, days:3, severity:'major', blurb:'Liquidity surge from new venue.', requires:['crypto']},
+  {scope:'asset', sym:'ETH', title:'Staking yield spike', type:'crypto_flow', mu:+0.0015, sigma:+0.014, demand:+0.08, days:3, severity:'major', blurb:'Validators flock after upgrade.', requires:['crypto']},
+  {scope:'asset', sym:'MOON', title:'Moonshot social buzz', type:'crypto_flow', mu:+0.0025, sigma:+0.020, demand:+0.12, days:2, severity:'major', blurb:'Viral meme drives FOMO.', requires:['crypto']},
   {scope:'asset', sym:'{TIP_SYM}', title:'Whispers on the street', type:'insider', mu:+0.0010, sigma:+0.010, demand:+0.05, days:2, severity:'minor', blurb:'Unusual chatter favors near‑term upside.', requires:['insider']}
 ];
 

--- a/src/js/core/priceModel.js
+++ b/src/js/core/priceModel.js
@@ -69,6 +69,31 @@ export function applyOvernightOutlook(ctx){
 
     let mu    = gMu + evMu + valuation + streakMR + demandTerm + reversion;
     let sigma = clamp(0.006 + evVol*0.6 + Math.abs(gDem)*0.15, 0.006, 0.10);
+
+    // Moon coin burst dynamics
+    if (a.sym === 'MOON') {
+      if (!a.moonBurst || a.moonBurst.daysLeft <= 0) {
+        if (Math.random() < CFG.MOON_BURST_P) {
+          const [dMin,dMax] = CFG.MOON_BURST_DAYS_RANGE;
+          const days = Math.floor(dMin + Math.random() * (dMax - dMin + 1));
+          const [muMin,muMax] = CFG.MOON_BURST_MU_RANGE;
+          const [sigMin,sigMax] = CFG.MOON_BURST_SIGMA_RANGE;
+          a.moonBurst = {
+            daysLeft: days,
+            mu: muMin + Math.random() * (muMax - muMin),
+            sigma: sigMin + Math.random() * (sigMax - sigMin)
+          };
+        } else {
+          a.moonBurst = null;
+        }
+      }
+      if (a.moonBurst) {
+        mu += a.moonBurst.mu;
+        sigma += a.moonBurst.sigma;
+        a.moonBurst.daysLeft--;
+      }
+    }
+
     if (ctx.state.insiderTip && ctx.state.insiderTip.daysLeft > 0 && ctx.state.insiderTip.sym === a.sym) {
       const [muMin, muMax] = CFG.INSIDER_MU_RANGE;
       const [sigMin, sigMax] = CFG.INSIDER_SIGMA_RANGE;

--- a/src/js/test/crypto.spec.js
+++ b/src/js/test/crypto.spec.js
@@ -1,0 +1,47 @@
+import assert from 'assert';
+import { CFG, ASSET_DEFS } from '../config.js';
+import { createInitialState } from '../core/state.js';
+import { startDay } from '../core/cycle.js';
+import { randomEvent } from '../core/events.js';
+import { createRNG } from '../util/rng.js';
+
+// Moon burst window boosts mu and sigma
+{
+  const oldP = CFG.MOON_BURST_P;
+  CFG.MOON_BURST_P = 0;
+  const ctx0 = createInitialState(ASSET_DEFS);
+  const moon0 = ctx0.assets.find(a => a.sym === 'MOON');
+  startDay(ctx0, { ...CFG, AH_EVENT_P:0, AH_SUPPLY_EVENT_P:0 });
+  const baseMu = moon0.outlook.mu;
+  const baseSig = moon0.outlook.sigma;
+
+  CFG.MOON_BURST_P = 1;
+  const ctx1 = createInitialState(ASSET_DEFS);
+  const moon1 = ctx1.assets.find(a => a.sym === 'MOON');
+  startDay(ctx1, { ...CFG, AH_EVENT_P:0, AH_SUPPLY_EVENT_P:0 });
+  assert(moon1.outlook.mu > baseMu, 'mu should be boosted during burst');
+  assert(moon1.outlook.sigma > baseSig, 'sigma should be boosted during burst');
+  assert(moon1.moonBurst && moon1.moonBurst.daysLeft >= CFG.MOON_BURST_DAYS_RANGE[0]-1,
+    'burst window days set');
+  CFG.MOON_BURST_P = oldP;
+}
+
+// Crypto events gated by upgrade
+{
+  const rng = createRNG(123);
+  const ctx = createInitialState(ASSET_DEFS);
+  ctx.state.upgrades.crypto = false;
+  for(let i=0;i<20;i++){
+    const ev = randomEvent(ctx, rng);
+    assert(!ev.requires || !ev.requires.includes('crypto'), 'no crypto events when locked');
+  }
+  ctx.state.upgrades.crypto = true;
+  let seen = false;
+  for(let i=0;i<50;i++){
+    const ev = randomEvent(ctx, rng);
+    if(ev.requires && ev.requires.includes('crypto')) { seen = true; break; }
+  }
+  assert(seen, 'crypto events appear when unlocked');
+}
+
+console.log('crypto.spec passed');

--- a/src/js/ui/table.js
+++ b/src/js/ui/table.js
@@ -5,7 +5,7 @@ import { openOptionsDialog } from './options.js';
 export function buildMarketTable({ tbody, assets, state, onSelect, onBuy, onSell, onOption }){
   tbody.innerHTML = '';
   for (const a of assets){
-    const tr = document.createElement('tr'); tr.dataset.sym = a.sym;
+    const tr = document.createElement('tr'); tr.dataset.sym = a.sym; if (a.isCrypto) tr.dataset.crypto = '1';
     tr.innerHTML = `
       <td><b>${a.sym}</b> <span class="mini">• ${a.name}</span></td>
       <td class="price" id="p-${a.sym}"></td>
@@ -90,5 +90,14 @@ export function renderMarketTable(ctx){
     const t = a.analyst?.tone || 'Neutral', cls = a.analyst?.cls || 'neu';
     const conf = Math.round((a.analyst?.conf || 0.5) * 100);
     if (badge) badge.innerHTML = `<span class="analyst ${cls}">${t}</span> <span class="mini">(${conf}% conf)</span>`;
+
+    const tr = document.querySelector(`tr[data-sym="${a.sym}"]`);
+    if (tr) {
+      if (a.isCrypto) {
+        tr.style.display = (ctx.state.upgrades.crypto && ctx.marketTab === 'crypto') ? '' : 'none';
+      } else {
+        tr.style.display = (ctx.marketTab === 'crypto') ? 'none' : '';
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- integrate crypto assets (BTC, ETH, MOON) and configuration knobs
- implement Moon coin burst mechanics and crypto-specific events
- add crypto market tab UI with gating and supporting tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ed99b2680832aa28a9bf6a1b507b8