### PR TITLE
Clarify insider tips with bullish/bearish bias

### DIFF
--- a/src/js/core/events.js
+++ b/src/js/core/events.js
@@ -23,15 +23,16 @@ export function randomEvent(ctx, rng, newsLevel=0){
   let pool = EVENT_POOL.filter(ev => !ev.requires || ev.requires.every(id => ctx.state.upgrades[id]));
   pool = pool.map(ev => {
     if (ev.sym === '{TIP_SYM}' && ctx.state.insiderTip) {
-      return { ...ev, sym: ctx.state.insiderTip.sym };
+      const tip = ctx.state.insiderTip;
+      return { ...ev, sym: tip.sym, mu: ev.mu * tip.bias, demand: ev.demand * tip.bias };
     }
     return ev;
   });
   if (ctx.state.insiderTip && ctx.state.insiderTip.daysLeft > 0) {
-    const sym = ctx.state.insiderTip.sym;
+    const { sym, bias } = ctx.state.insiderTip;
     const extras = [];
     for (const ev of pool) {
-      if (ev.sym === sym && ev.mu > 0) extras.push(ev);
+      if (ev.sym === sym && ((bias > 0 && ev.mu > 0) || (bias < 0 && ev.mu < 0))) extras.push(ev);
     }
     pool = pool.concat(extras);
   }

--- a/src/js/core/priceModel.js
+++ b/src/js/core/priceModel.js
@@ -95,10 +95,9 @@ export function applyOvernightOutlook(ctx){
     }
 
     if (ctx.state.insiderTip && ctx.state.insiderTip.daysLeft > 0 && ctx.state.insiderTip.sym === a.sym) {
-      const [muMin, muMax] = CFG.INSIDER_MU_RANGE;
-      const [sigMin, sigMax] = CFG.INSIDER_SIGMA_RANGE;
-      mu += muMin + Math.random() * (muMax - muMin);
-      sigma += sigMin + Math.random() * (sigMax - sigMin);
+      const tip = ctx.state.insiderTip;
+      mu += tip.mu;
+      sigma += tip.sigma;
       sigma = clamp(sigma, 0.006, 0.12);
     }
     const gap   = clamp( (gMu*CFG.DAY_TICKS*0.35) + (evMu*CFG.DAY_TICKS*0.75) + (evDem*0.55), -CFG.OPEN_GAP_CAP, CFG.OPEN_GAP_CAP);

--- a/src/js/ui/insight.js
+++ b/src/js/ui/insight.js
@@ -22,8 +22,14 @@ export function renderInsight(ctx){
     const posneg = (ev.mu + ev.demand) >= 0 ? 'pos' : 'neg';
     const who = ev.scope === 'global' ? 'GLOBAL' : a.sym;
     const days = ev.days ? ` • ${ev.days}d` : '';
-    const eff = `Bias ${ev.mu>=0?'+':''}${(ev.mu*10000).toFixed(0)}bp • Demand ${ev.demand>=0?'+':''}${(ev.demand*100).toFixed(1)}% • Vol ${ev.sigma>=0?'+':''}${(ev.sigma*100).toFixed(1)}%`;
-    const tip = `μ ${(ev.mu*10000).toFixed(0)}bp • σ ${(ev.sigma*100).toFixed(1)}% • D ${(ev.demand*100).toFixed(1)}%`;
+    let eff, tip;
+    if (ev.type === 'insider') {
+      eff = ev.mu >= 0 ? 'Bullish Tip' : 'Bearish Tip';
+      tip = eff;
+    } else {
+      eff = `Bias ${ev.mu>=0?'+':''}${(ev.mu*10000).toFixed(0)}bp • Demand ${ev.demand>=0?'+':''}${(ev.demand*100).toFixed(1)}% • Vol ${ev.sigma>=0?'+':''}${(ev.sigma*100).toFixed(1)}%`;
+      tip = `μ ${(ev.mu*10000).toFixed(0)}bp • σ ${(ev.sigma*100).toFixed(1)}% • D ${(ev.demand*100).toFixed(1)}%`;
+    }
     return `<div class="news-item">
       <b>${rec.when}</b> — <span>${who}: ${ev.title}</span>
       <span class="chip ${maj}">${ev.severity}</span>

--- a/src/js/ui/newsAssets.js
+++ b/src/js/ui/newsAssets.js
@@ -12,8 +12,14 @@ export function renderAssetNewsTable(ctx){
   </tr></thead><tbody>`];
   for (const rec of list.slice(0,40)){
     const ev = rec.ev;
-    const eff = `Bias ${ev.mu>=0?'+':''}${(ev.mu*10000).toFixed(0)}bp • Demand ${ev.demand>=0?'+':''}${(ev.demand*100).toFixed(1)}% • Vol ${ev.sigma>=0?'+':''}${(ev.sigma*100).toFixed(1)}%`;
-    const tip = `μ ${(ev.mu*10000).toFixed(0)}bp • σ ${(ev.sigma*100).toFixed(1)}% • D ${(ev.demand*100).toFixed(1)}%`;
+    let eff, tip;
+    if (ev.type === 'insider') {
+      eff = ev.mu >= 0 ? 'Bullish Tip' : 'Bearish Tip';
+      tip = eff;
+    } else {
+      eff = `Bias ${ev.mu>=0?'+':''}${(ev.mu*10000).toFixed(0)}bp • Demand ${ev.demand>=0?'+':''}${(ev.demand*100).toFixed(1)}% • Vol ${ev.sigma>=0?'+':''}${(ev.sigma*100).toFixed(1)}%`;
+      tip = `μ ${(ev.mu*10000).toFixed(0)}bp • σ ${(ev.sigma*100).toFixed(1)}% • D ${(ev.demand*100).toFixed(1)}%`;
+    }
     rows.push(`<tr>
       <td>${rec.when}</td>
       <td>${ev.scope==='global'?'GLOBAL: ':''}${ev.title}</td>


### PR DESCRIPTION
## Summary
- Allow insider tips to be bullish or bearish and bias future events accordingly
- Show tip orientation and simplified effect text in Asset Insight and news tables
- Record tip mu/sigma for price outlook and test the bias application

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689edeb9ef6c832a8f0b0b4618c9b101