### PR TITLE
Implement HUD rendering and persistent saves

### DIFF
--- a/src/js/core/persist.js
+++ b/src/js/core/persist.js
@@ -1,4 +1,37 @@
-// save/load, schema versioning
-export function save(state) {
-  // TODO: persist state
+const KEY = 'ttm_save';
+export const SAVE_VERSION = 1;
+
+export function save(state, market, assets, version = SAVE_VERSION) {
+  try {
+    const payload = {
+      version,
+      state,
+      market,
+      assets: assets.map(a => ({ ...a, history: a.history.slice(-700) }))
+    };
+    localStorage.setItem(KEY, JSON.stringify(payload));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function load(ctx, version = SAVE_VERSION) {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return false;
+    const data = JSON.parse(raw);
+    if (data.version !== version) return false;
+    Object.assign(ctx.state, data.state || {});
+    Object.assign(ctx.market, data.market || {});
+    for (const a of ctx.assets) {
+      const m = (data.assets || []).find(x => x.sym === a.sym);
+      if (!m) continue;
+      Object.assign(a, m);
+      a.history = Array.isArray(m.history) && m.history.length ? m.history : a.history;
+    }
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/src/js/ui/hud.js
+++ b/src/js/ui/hud.js
@@ -1,4 +1,47 @@
-// header pills, risk meter
-export function renderHud() {
-  // TODO: implement HUD rendering
+import { fmt } from '../util/format.js';
+import { clamp } from '../util/math.js';
+
+const last = {};
+
+function portfolioValue(ctx) {
+  let v = 0;
+  for (const a of ctx.assets) v += (ctx.state.positions[a.sym] || 0) * a.price;
+  for (const m of ctx.state.marginPositions) {
+    const a = ctx.assets.find(x => x.sym === m.sym);
+    if (a) v += m.qty * a.price;
+  }
+  return v;
+}
+
+function netWorth(ctx, pv) { return ctx.state.cash + pv - ctx.state.debt; }
+
+function updatePill(id, val, formatter) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  const prev = last[id];
+  el.textContent = formatter(val);
+  el.classList.remove('up', 'down');
+  if (prev !== undefined) {
+    if (val > prev) el.classList.add('up');
+    else if (val < prev) el.classList.add('down');
+  }
+  last[id] = val;
+}
+
+export function renderHUD(ctx) {
+  document.getElementById('dayNum').textContent = ctx.day.idx;
+  document.getElementById('dayTimer').textContent = ctx.day.active
+    ? String(ctx.day.ticksLeft).padStart(2, '0') + 's'
+    : '\u2014s';
+
+  const assets = portfolioValue(ctx);
+  const net = netWorth(ctx, assets);
+
+  updatePill('cash', ctx.state.cash, fmt);
+  updatePill('debt', ctx.state.debt, fmt);
+  updatePill('assets', assets, fmt);
+  updatePill('net', net, fmt);
+
+  const riskPct = clamp((ctx.market.risk - 0.05) / 1.15 * 100, 0, 100);
+  updatePill('riskPct', riskPct, v => Math.round(v) + '%');
 }


### PR DESCRIPTION
## Summary
- Move HUD rendering to dedicated module with delta highlighting and risk meter
- Add versioned save/load utilities and integrate save/load into app controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689eea9cf308832a9753278e1ede55cd