### PR TITLE
refactor: simplify auto-risk controls

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -50,6 +50,9 @@ button.bad{background:#2a1313;border-color:#3b1b1b}
 canvas{width:100%;height:100%;background:#0a1017;border:1px solid var(--border);border-radius:8px}
 .statgrid{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin-top:8px}
 .stat{background:#0a1017;border:1px solid var(--border);border-radius:8px;padding:8px}
+.slider{display:flex;align-items:center;gap:6px;margin-top:4px}
+.slider input[type=range]{flex:1}
+.slider span{width:32px;text-align:right}
 .feed{max-height:220px;overflow:auto;padding-right:4px}
 .feed .line{padding:6px 4px;border-bottom:1px dashed rgba(255,255,255,.06);font-variant-numeric:tabular-nums}
 

--- a/src/js/ui/risktools.js
+++ b/src/js/ui/risktools.js
@@ -25,45 +25,45 @@ export function initRiskTools(root, ctx, toast){
       <div class="mini section-title">Protection</div>
       <div class="statgrid">
         <div class="stat">
-          <div class="mini">Trailing stop (%)</div>
-          <input id="rt-trailing" type="number" min="0" step="0.01">
+          <div class="mini" title="Sell after price falls from peak by this percent">Trailing stop</div>
+          <div class="slider"><input id="rt-trailing" type="range" min="0" max="50" step="1"><span class="mini" id="rt-trailing-val"></span></div>
         </div>
         <div class="stat">
-          <div class="mini">Hard stop (%)</div>
-          <input id="rt-hard" type="number" min="0" step="0.01">
+          <div class="mini" title="Maximum loss tolerated on a position">Hard stop</div>
+          <div class="slider"><input id="rt-hard" type="range" min="0" max="60" step="1"><span class="mini" id="rt-hard-val"></span></div>
         </div>
         <div class="stat">
-          <div class="mini">Stop sell fraction (0–1)</div>
-          <input id="rt-stopfrac" type="number" min="0.05" max="1" step="0.05">
+          <div class="mini" title="Fraction of position sold when a stop triggers">Stop sell fraction</div>
+          <div class="slider"><input id="rt-stopfrac" type="range" min="5" max="100" step="5"><span class="mini" id="rt-stopfrac-val"></span></div>
         </div>
       </div>
     </div>
     <div class="section">
-      <div class="mini section-title">Profit taking</div>
+      <div class="mini section-title">Take-Profit Ladder</div>
       <div class="statgrid">
         <div class="stat">
-          <div class="mini">TP1 threshold (%)</div>
-          <input id="rt-tp1" type="number" min="0.05" step="0.05">
+          <div class="mini" title="Gain needed to trigger the first take profit">TP1 threshold</div>
+          <div class="slider"><input id="rt-tp1" type="range" min="5" max="200" step="5"><span class="mini" id="rt-tp1-val"></span></div>
         </div>
         <div class="stat">
-          <div class="mini">TP1 sell fraction (0–1)</div>
-          <input id="rt-tp1f" type="number" min="0.05" max="1" step="0.05">
+          <div class="mini" title="Percent of position sold at TP1">TP1 sell fraction</div>
+          <div class="slider"><input id="rt-tp1f" type="range" min="5" max="100" step="5"><span class="mini" id="rt-tp1f-val"></span></div>
         </div>
         <div class="stat">
-          <div class="mini">TP2 threshold (%)</div>
-          <input id="rt-tp2" type="number" min="0.05" step="0.05">
+          <div class="mini" title="Gain needed to trigger the second take profit">TP2 threshold</div>
+          <div class="slider"><input id="rt-tp2" type="range" min="5" max="200" step="5"><span class="mini" id="rt-tp2-val"></span></div>
         </div>
         <div class="stat">
-          <div class="mini">TP2 sell fraction (0–1)</div>
-          <input id="rt-tp2f" type="number" min="0.05" max="1" step="0.05">
+          <div class="mini" title="Percent of position sold at TP2">TP2 sell fraction</div>
+          <div class="slider"><input id="rt-tp2f" type="range" min="5" max="100" step="5"><span class="mini" id="rt-tp2f-val"></span></div>
         </div>
         <div class="stat">
-          <div class="mini">TP3 threshold (%)</div>
-          <input id="rt-tp3" type="number" min="0.05" step="0.05">
+          <div class="mini" title="Gain needed to trigger the third take profit">TP3 threshold</div>
+          <div class="slider"><input id="rt-tp3" type="range" min="5" max="200" step="5"><span class="mini" id="rt-tp3-val"></span></div>
         </div>
         <div class="stat">
-          <div class="mini">TP3 sell fraction (0–1)</div>
-          <input id="rt-tp3f" type="number" min="0.05" max="1" step="0.05">
+          <div class="mini" title="Percent of position sold at TP3">TP3 sell fraction</div>
+          <div class="slider"><input id="rt-tp3f" type="range" min="5" max="100" step="5"><span class="mini" id="rt-tp3f-val"></span></div>
         </div>
       </div>
     </div>
@@ -71,13 +71,13 @@ export function initRiskTools(root, ctx, toast){
       <div class="mini section-title">Exposure cap</div>
       <div class="statgrid">
         <div class="stat">
-          <div class="mini">Position cap (% of net)</div>
-          <input id="rt-cap" type="number" min="0.05" max="1" step="0.05">
+          <div class="mini" title="Maximum portfolio allocation to a single position">Position cap</div>
+          <div class="slider"><input id="rt-cap" type="range" min="5" max="100" step="5"><span class="mini" id="rt-cap-val"></span></div>
         </div>
       </div>
     </div>
     <div class="row" style="justify-content:flex-end;margin-top:8px;">
-      <span class="mini" id="rt-status" style="flex:1"></span>
+      <span class="mini" id="rt-summary" style="flex:1"></span>
       <button id="rt-apply" class="accent">Apply</button>
     </div>
   `;
@@ -86,46 +86,61 @@ export function initRiskTools(root, ctx, toast){
 
   function hydrate(){
     byId('rt-enabled').checked = !!cfg.enabled;
-    byId('rt-trailing').value = String((cfg.trailing||0.12).toFixed(2));
-    byId('rt-hard').value     = String((cfg.hardStop||0.18).toFixed(2));
-    byId('rt-stopfrac').value = String((cfg.stopSellFrac||1.0).toFixed(2));
-    byId('rt-cap').value      = String((cfg.posCap||0.35).toFixed(2));
-    byId('rt-tp1').value      = String((cfg.tp1||0.20).toFixed(2));
-    byId('rt-tp1f').value     = String((cfg.tp1Frac||0.25).toFixed(2));
-    byId('rt-tp2').value      = String((cfg.tp2||0.40).toFixed(2));
-    byId('rt-tp2f').value     = String((cfg.tp2Frac||0.25).toFixed(2));
-    byId('rt-tp3').value      = String((cfg.tp3||0.80).toFixed(2));
-    byId('rt-tp3f').value     = String((cfg.tp3Frac||0.50).toFixed(2));
+    byId('rt-trailing').value = String(Math.round((cfg.trailing||0.12)*100));
+    byId('rt-hard').value     = String(Math.round((cfg.hardStop||0.18)*100));
+    byId('rt-stopfrac').value = String(Math.round((cfg.stopSellFrac||1.0)*100));
+    byId('rt-cap').value      = String(Math.round((cfg.posCap||0.35)*100));
+    byId('rt-tp1').value      = String(Math.round((cfg.tp1||0.20)*100));
+    byId('rt-tp1f').value     = String(Math.round((cfg.tp1Frac||0.25)*100));
+    byId('rt-tp2').value      = String(Math.round((cfg.tp2||0.40)*100));
+    byId('rt-tp2f').value     = String(Math.round((cfg.tp2Frac||0.25)*100));
+    byId('rt-tp3').value      = String(Math.round((cfg.tp3||0.80)*100));
+    byId('rt-tp3f').value     = String(Math.round((cfg.tp3Frac||0.50)*100));
+    ['trailing','hard','stopfrac','cap','tp1','tp1f','tp2','tp2f','tp3','tp3f'].forEach(k=>{
+      byId(`rt-${k}-val`).textContent = byId(`rt-${k}`).value + '%';
+    });
+    updateSummary();
   }
   hydrate();
 
   function apply(){
     cfg.enabled = byId('rt-enabled').checked;
-    cfg.trailing = Math.max(0, parseFloat(byId('rt-trailing').value)||0);
-    cfg.hardStop = Math.max(0, parseFloat(byId('rt-hard').value)||0);
-    cfg.stopSellFrac = Math.min(1, Math.max(0.05, parseFloat(byId('rt-stopfrac').value)||1));
-    cfg.posCap = Math.min(1, Math.max(0.05, parseFloat(byId('rt-cap').value)||0.35));
-    cfg.tp1 = Math.max(0, parseFloat(byId('rt-tp1').value)||0.2);
-    cfg.tp1Frac = Math.min(1, Math.max(0.05, parseFloat(byId('rt-tp1f').value)||0.25));
-    cfg.tp2 = Math.max(0, parseFloat(byId('rt-tp2').value)||0.4);
-    cfg.tp2Frac = Math.min(1, Math.max(0.05, parseFloat(byId('rt-tp2f').value)||0.25));
-    cfg.tp3 = Math.max(0, parseFloat(byId('rt-tp3').value)||0.8);
-    cfg.tp3Frac = Math.min(1, Math.max(0.05, parseFloat(byId('rt-tp3f').value)||0.5));
+    cfg.trailing = Math.max(0, parseFloat(byId('rt-trailing').value)||0)/100;
+    cfg.hardStop = Math.max(0, parseFloat(byId('rt-hard').value)||0)/100;
+    cfg.stopSellFrac = Math.min(1, Math.max(0.05, parseFloat(byId('rt-stopfrac').value)||100)/100);
+    cfg.posCap = Math.min(1, Math.max(0.05, parseFloat(byId('rt-cap').value)||35)/100);
+    cfg.tp1 = Math.max(0, parseFloat(byId('rt-tp1').value)||20)/100;
+    cfg.tp1Frac = Math.min(1, Math.max(0.05, parseFloat(byId('rt-tp1f').value)||25)/100);
+    cfg.tp2 = Math.max(0, parseFloat(byId('rt-tp2').value)||40)/100;
+    cfg.tp2Frac = Math.min(1, Math.max(0.05, parseFloat(byId('rt-tp2f').value)||25)/100);
+    cfg.tp3 = Math.max(0, parseFloat(byId('rt-tp3').value)||80)/100;
+    cfg.tp3Frac = Math.min(1, Math.max(0.05, parseFloat(byId('rt-tp3f').value)||50)/100);
     save(cfg);
+    updateSummary();
     if (toast) {
       toast('Saved', 'good');
-      const status = document.getElementById('rt-status');
-      if (status) {
-        status.textContent = 'Saved';
-        setTimeout(() => { status.textContent = ''; }, 1200);
-      }
     }
   }
   document.getElementById('rt-apply').addEventListener('click', apply);
 
+  ['rt-trailing','rt-hard','rt-stopfrac','rt-cap','rt-tp1','rt-tp1f','rt-tp2','rt-tp2f','rt-tp3','rt-tp3f']
+    .forEach(id => {
+      const el = byId(id);
+      el.addEventListener('input', () => { byId(id+'-val').textContent = el.value + '%'; });
+    });
+
   // Save immediately on toggle/enter
   ['rt-enabled','rt-trailing','rt-hard','rt-stopfrac','rt-cap','rt-tp1','rt-tp1f','rt-tp2','rt-tp2f','rt-tp3','rt-tp3f']
-    .forEach(id => document.getElementById(id).addEventListener('change', apply));
+    .forEach(id => byId(id).addEventListener('change', apply));
+
+  function pct(v){ return Math.round(v*100)+'%'; }
+  function updateSummary(){
+    const txt = cfg.enabled
+      ? `TS ${pct(cfg.trailing)} • HS ${pct(cfg.hardStop)} • Cap ${pct(cfg.posCap)} • TP1 ${pct(cfg.tp1)}/${pct(cfg.tp1Frac)} • TP2 ${pct(cfg.tp2)}/${pct(cfg.tp2Frac)} • TP3 ${pct(cfg.tp3)}/${pct(cfg.tp3Frac)}`
+      : 'Disabled';
+    const el = document.getElementById('rt-summary');
+    if (el) el.textContent = txt;
+  }
 
   // Presets
   const presets = {


### PR DESCRIPTION
## Summary
- simplify Auto Risk Tools UI with grouped sliders, percent labels, and tooltips
- show current risk settings summary and "Saved" toast when applying

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689eeada0ed8832a8924fc71d57c9001