### PR TITLE
Enhance News panel and event gating

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -44,8 +44,9 @@ button.bad{background:#2a1313;border-color:#3b1b1b}
 #marketTable th:nth-child(7){width:30%}
 .market-col,.mid-col,.right-rail{display:grid;gap:16px}
 .right-rail{width:320px}
-#newsScroll{max-height:28rem;overflow:auto;padding-right:4px}
-@media (max-width:600px){#newsScroll{max-height:18rem}}
+#newsPanel.collapsed{display:none}
+#newsScroll{height:28rem;overflow:auto;padding-right:4px}
+@media (max-width:600px){#newsScroll{height:18rem}}
 .chart-wrap{height:260px;position:relative}
 canvas{width:100%;height:100%;background:#0a1017;border:1px solid var(--border);border-radius:8px}
 .statgrid{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin-top:8px}
@@ -77,6 +78,12 @@ canvas{width:100%;height:100%;background:#0a1017;border:1px solid var(--border);
 .chip.neg{color:#ffb3b3;border-color:#3a2121}
 .chip-btn{font-size:10px;padding:2px 6px;border:1px solid var(--border);border-radius:999px;background:var(--btn);color:var(--muted);cursor:pointer}
 .chip-btn:hover{background:var(--btn-hover)}
+
+#newsTable tr.major{background:rgba(246,193,119,.08)}
+#newsTable tr.major:hover{background:rgba(246,193,119,.12)}
+td.scope{width:20px;text-align:center}
+td.scope.global{color:var(--warn)}
+td.scope.asset{color:var(--accent)}
 .section{margin-top:8px}
 .section-title{margin-bottom:4px;display:block}
 /* ===== Summary modal ===== */

--- a/src/index.html
+++ b/src/index.html
@@ -55,14 +55,20 @@
       <div class="statgrid" id="chartStats"></div>
     </div>
 
-    <div class="card">
-      <div class="row" style="justify-content:space-between;">
-        <div>News & Events — <b id="newsSymbol"></b></div>
-        <div class="mini">Follow the selected asset</div>
+      <div class="card">
+        <div class="row" style="justify-content:space-between;">
+          <div>News & Events — <b id="newsSymbol"></b></div>
+          <div class="row" style="align-items:center;">
+            <div class="mini">Follow the selected asset</div>
+            <button id="majorOnly" class="chip-btn">Major</button>
+            <button id="newsCollapse" class="chip-btn">Collapse</button>
+          </div>
+        </div>
+        <div id="newsPanel">
+          <div id="newsScroll"><div id="newsTable"></div></div>
+        </div>
       </div>
-      <div id="newsScroll"><div id="newsTable"></div></div>
-    </div>
-  </section>
+    </section>
 
   <section class="right-rail">
     <div class="card" id="portfolio"></div>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -14,7 +14,7 @@ import { initToaster } from './ui/toast.js';
 import { buildMarketTable, renderMarketTable } from './ui/table.js';
 import { drawChart } from './ui/chart.js';
 import { renderInsight } from './ui/insight.js';
-import { renderAssetNewsTable } from './ui/newsAssets.js';
+import { renderAssetNewsTable, initNewsControls } from './ui/newsAssets.js';
 import { showSummary, showGameOver } from './ui/modal.js';
 import { initRiskTools } from './ui/risktools.js';
 import { renderPortfolio } from './ui/portfolio.js';
@@ -75,6 +75,8 @@ document.getElementById('chartTitle').textContent =
   }
   ctx.renderMarketTabs = renderTabs;
   renderTabs();
+
+  initNewsControls(ctx);
 
 // Chart type toggle
 ctx.chartMode = 'line';

--- a/src/js/core/cycle.js
+++ b/src/js/core/cycle.js
@@ -48,7 +48,7 @@ export function stepTick(ctx, cfg, rng, hooks){
     ev.timing = 'intraday'; ev.t = cfg.DAY_TICKS * 2;
     ctx.market.activeEvents.push(ev);
     hooks?.log?.(`${ev.scope==='global'?'GLOBAL':ev.sym}: ${ev.title} (intraday) — ${ev.blurb}`);
-    pushAssetNews(ctx.newsByAsset, ev, `Day ${ctx.day.idx} (intraday)`);
+    pushAssetNews(ctx.newsByAsset, ev, `Day ${ctx.day.idx} (intraday)`, ctx.state);
     ctx.day.midEventFired = true;
   }
 
@@ -125,12 +125,12 @@ export function enqueueAfterHours(ctx, cfg, rng, hooks){
     const ev = randomEvent(ctx, rng); ev.timing = 'afterhours';
     ctx.market.tomorrow.push(ev);
     hooks?.log?.(`${ev.scope==='global'?'GLOBAL':ev.sym} (after‑hours): ${ev.title} — ${ev.blurb}`);
-    pushAssetNews(ctx.newsByAsset, ev, `Day ${ctx.day.idx} (after‑hours)`);
+    pushAssetNews(ctx.newsByAsset, ev, `Day ${ctx.day.idx} (after‑hours)`, ctx.state);
   }
   if (Math.random() < cfg.AH_SUPPLY_EVENT_P){
     const sev = randomSupplyEvent(ctx.assets, rng); sev.timing = 'afterhours';
     ctx.market.tomorrow.push(sev);
     hooks?.log?.(`${sev.scope==='global'?'GLOBAL':sev.sym} (after‑hours): ${sev.title} — ${sev.blurb}`);
-    pushAssetNews(ctx.newsByAsset, sev, `Day ${ctx.day.idx} (after‑hours)`);
+    pushAssetNews(ctx.newsByAsset, sev, `Day ${ctx.day.idx} (after‑hours)`, ctx.state);
   }
 }

--- a/src/js/core/events.js
+++ b/src/js/core/events.js
@@ -62,7 +62,8 @@ export function randomSupplyEvent(assets, rng){
           severity:(Math.abs(frac)>0.05 ? "major":"minor"), blurb:`Supply ${up?"+":""}${Math.round(frac*100)}%.`};
 }
 
-export function pushAssetNews(newsByAsset, ev, whenLabel){
+export function pushAssetNews(newsByAsset, ev, whenLabel, state){
+  if (ev.requires && state && !ev.requires.every(id => state.upgrades[id])) return;
   const targets = ev.scope === 'asset' ? [ev.sym] : null;
   if (targets) {
     newsByAsset[ev.sym] = newsByAsset[ev.sym] || [];

--- a/src/js/ui/insight.js
+++ b/src/js/ui/insight.js
@@ -16,11 +16,13 @@ export function renderInsight(ctx){
 
   const news = document.getElementById('assetNews');
   const list = (ctx.newsByAsset && ctx.newsByAsset[a.sym]) || [];
-  news.innerHTML = list.slice(0,8).map(rec => {
+  const filtered = list.filter(rec => !rec.ev.requires || rec.ev.requires.every(id => ctx.state.upgrades[id]));
+  news.innerHTML = filtered.slice(0,8).map(rec => {
     const ev = rec.ev;
     const maj = ev.severity === 'major' ? 'major' : '';
     const posneg = (ev.mu + ev.demand) >= 0 ? 'pos' : 'neg';
-    const who = ev.scope === 'global' ? 'GLOBAL' : a.sym;
+    const icon = ev.scope === 'global' ? '🌐' : '📈';
+    const label = ev.scope === 'global' ? 'GLOBAL' : a.sym;
     const days = ev.days ? ` • ${ev.days}d` : '';
     let eff, tip;
     if (ev.type === 'insider') {
@@ -31,7 +33,7 @@ export function renderInsight(ctx){
       tip = `μ ${(ev.mu*10000).toFixed(0)}bp • σ ${(ev.sigma*100).toFixed(1)}% • D ${(ev.demand*100).toFixed(1)}%`;
     }
     return `<div class="news-item">
-      <b>${rec.when}</b> — <span>${who}: ${ev.title}</span>
+      <b>${rec.when}</b> — <span>${icon} ${label}: ${ev.title}</span>
       <span class="chip ${maj}">${ev.severity}</span>
       <span class="chip ${posneg}" title="${tip}">${eff}</span>
       <span class="chip">${ev.type}${days}</span>

--- a/src/js/ui/newsAssets.js
+++ b/src/js/ui/newsAssets.js
@@ -1,8 +1,27 @@
+let showMajorOnly = false;
+
+export function initNewsControls(ctx){
+  const collapseBtn = document.getElementById('newsCollapse');
+  const majorBtn = document.getElementById('majorOnly');
+  const panel = document.getElementById('newsPanel');
+  collapseBtn.addEventListener('click', () => {
+    const collapsed = panel.classList.toggle('collapsed');
+    collapseBtn.textContent = collapsed ? 'Expand' : 'Collapse';
+  });
+  majorBtn.addEventListener('click', () => {
+    showMajorOnly = !showMajorOnly;
+    majorBtn.classList.toggle('accent', showMajorOnly);
+    renderAssetNewsTable(ctx);
+  });
+}
+
 export function renderAssetNewsTable(ctx){
   const a = ctx.assets.find(x => x.sym === ctx.selected) || ctx.assets[0];
   document.getElementById('newsSymbol').textContent = `${a.sym} — ${a.name}`;
   const cont = document.getElementById('newsTable');
-  const list = (ctx.newsByAsset && ctx.newsByAsset[a.sym]) || [];
+  let list = (ctx.newsByAsset && ctx.newsByAsset[a.sym]) || [];
+  list = list.filter(rec => !rec.ev.requires || rec.ev.requires.every(id => ctx.state.upgrades[id]));
+  if (showMajorOnly) list = list.filter(rec => rec.ev.severity === 'major');
   cont.innerHTML = '';
   if (!list.length){
     cont.innerHTML = `<div class="mini">No recent news for ${a.sym}.</div>`;
@@ -10,17 +29,21 @@ export function renderAssetNewsTable(ctx){
   }
 
   const table = document.createElement('table');
-  table.innerHTML = '<thead><tr><th>When</th><th>Title</th><th>Type</th><th>Severity</th><th>Effect</th><th>Timing</th></tr></thead>';
+  table.innerHTML = '<thead><tr><th>When</th><th></th><th>Title</th><th>Type</th><th>Severity</th><th>Effect</th><th>Timing</th></tr></thead>';
   const tbody = document.createElement('tbody');
   for (const rec of list.slice(0,40)){
     const ev = rec.ev;
     const tr = document.createElement('tr');
+    if (ev.severity === 'major') tr.classList.add('major');
+    const scopeIcon = ev.scope === 'global' ? '🌐' : '📈';
+    const scopeCls = ev.scope === 'global' ? 'global' : 'asset';
     const effect = ev.type === 'insider'
       ? (ev.mu >= 0 ? 'Bullish Tip' : 'Bearish Tip')
-      : `Bias ${ev.mu>=0?'+':''}${(ev.mu*10000).toFixed(0)}bp, Demand ${ev.demand>=0?'+':''}${(ev.demand*100).toFixed(1)}%, Vol ${ev.sigma>=0?'+':''}${(ev.sigma*100).toFixed(1)}%`;
+      : `Bias ${ev.mu>=0?'+':''}${(ev.mu*10000).toFixed(0)}bp, Demand ${ev.demand>=0?'+':''}${(ev.demand*100).toFixed(1)}%, Vol${ev.sigma>=0?'+':''}${(ev.sigma*100).toFixed(1)}%`;
     tr.innerHTML = `
       <td>${rec.when}</td>
-      <td>${ev.scope==='global'?'GLOBAL: ':''}${ev.title}</td>
+      <td class="scope ${scopeCls}">${scopeIcon}</td>
+      <td>${ev.title}</td>
       <td>${ev.type}</td>
       <td>${ev.severity}</td>
       <td>${effect}</td>

--- a/src/js/ui/upgrades.js
+++ b/src/js/ui/upgrades.js
@@ -81,7 +81,7 @@ export function renderUpgrades(ctx, toast){
         ctx.state.insiderTip = { sym, daysLeft: CFG.INSIDER_DAYS, mu, sigma, bias };
         ctx.state.cooldowns.insider = CFG.INSIDER_COOLDOWN_DAYS;
         ctx.state.upgrades.insider = true;
-        pushAssetNews(ctx.newsByAsset, { scope:'asset', sym, title: bias>0?'Bullish tip':'Bearish tip', type:'insider', mu, sigma, demand:0, days: CFG.INSIDER_DAYS, severity:'minor', blurb: bias>0?'Upward whispers.':'Downward whispers.' }, `Day ${ctx.day.idx} (tip)`);
+        pushAssetNews(ctx.newsByAsset, { scope:'asset', sym, title: bias>0?'Bullish tip':'Bearish tip', type:'insider', mu, sigma, demand:0, days: CFG.INSIDER_DAYS, severity:'minor', blurb: bias>0?'Upward whispers.':'Downward whispers.' }, `Day ${ctx.day.idx} (tip)`, ctx.state);
         msg = `Insider tip (${bias>0?'Bullish':'Bearish'}) purchased`;
       } else {
         ctx.state.cash -= cost;


### PR DESCRIPTION
## Summary
- Add scrollable, collapsible News & Events panel with major-event filter
- Distinguish global vs. asset news via icons and highlight major items
- Filter gated events in UI and core push logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689eeb15c124832a9f9be350481df707