### PR TITLE
Add help modal and contextual tooltips

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
         <div class="row">
           <button id="startBtn" class="accent">▶ Start Day</button>
           <button id="saveBtn">Save</button>
+          <button id="helpBtn">Help</button>
           <button id="resetBtn" class="bad">Hard Reset</button>
         </div>
       </div>

--- a/src/index.html
+++ b/src/index.html
@@ -27,6 +27,7 @@
         <div class="row">
           <button id="startBtn" class="accent">▶ Start Day</button>
           <button id="saveBtn">Save</button>
+          <button id="helpBtn">Help</button>
           <button id="resetBtn" class="bad">Hard Reset</button>
         </div>
       </div>

--- a/src/js/core/upgrades.js
+++ b/src/js/core/upgrades.js
@@ -3,6 +3,7 @@ export const UPGRADES = [
     baseCost:1500, costScale:1.25,
     kind:'consumable',
     desc:'Weekly paid tip pre-biases next week on a chosen asset.',
+    tip:'Choose an asset for a short-lived drift/volatility bias. Works once per purchase.',
     effect:'bias_mu_sigma',
     profitPotential:'Low–Moderate' },
 
@@ -10,21 +11,25 @@ export const UPGRADES = [
     baseCost:4000, costScale:1.35,
     levels:[2,5,10,25,50,100],
     desc:'Borrow to amplify exposure; risk of liquidation.',
+    tip:'Unlock margin trading. Higher levels magnify gains and losses and may trigger forced sells.',
     profitPotential:'High' },
 
   { id:'debt_rate', tier:2, name:'Preferred Rates',
     baseCost:3000, costScale:1.3,
     desc:'Reduce debt interest schedule / rate.',
+    tip:'Lowers daily interest charged on outstanding debt.',
     profitPotential:'Low–Moderate' },
 
   { id:'options', tier:3, name:'Options Trading',
     baseCost:6500, costScale:1.4,
     desc:'Buy/sell simple options; access to option-driven events.',
+    tip:'Adds calls and puts with limited expiry that can hedge or speculate.',
     profitPotential:'High' },
 
   { id:'crypto', tier:3, name:'Crypto Markets',
     baseCost:8000, costScale:1.45,
     desc:'Unlock crypto assets and moonshot coin dynamics.',
+    tip:'Adds highly volatile coins with unique events and price swings.',
     profitPotential:'Very High' }
 ];
 

--- a/src/js/ui/init.js
+++ b/src/js/ui/init.js
@@ -9,6 +9,7 @@ import { renderPortfolio } from './portfolio.js';
 import { renderUpgrades } from './upgrades.js';
 import { buy, sell } from '../core/trading.js';
 import { buyOption } from '../core/options.js';
+import { showHelp } from './modal.js';
 
 export function initUI(ctx, handlers) {
   const { start, save, reset } = handlers;
@@ -78,6 +79,7 @@ export function initUI(ctx, handlers) {
 
   document.getElementById('startBtn').addEventListener('click', start);
   document.getElementById('saveBtn').addEventListener('click', save);
+  document.getElementById('helpBtn').addEventListener('click', showHelp);
   document.getElementById('resetBtn').addEventListener('click', reset);
 
   initRiskTools(document.getElementById('riskTools'), ctx, toast);

--- a/src/js/ui/modal.js
+++ b/src/js/ui/modal.js
@@ -85,3 +85,23 @@ export function showGameOver(onReset){
   modalActions.appendChild(resetBtn);
   overlay.style.display = 'flex';
 }
+
+export function showHelp(){
+  const overlay = document.getElementById('overlay');
+  const modalContent = document.getElementById('modalContent');
+  const modalActions = document.getElementById('modalActions');
+
+  modalContent.innerHTML = `<h3>How to Play</h3>
+    <div class="mini">News and events shift tomorrow's price by biasing drift (μ) and volatility (σ). Positive news nudges prices up while negative news drags them down; effects fade over time.</div>
+    <div class="mini">Margin and leverage let you borrow to magnify exposure. Gains and losses scale with leverage and positions may liquidate if equity falls too low.</div>
+    <div class="mini">Debt accrues interest each day. Paying it down or buying Preferred Rates reduces the hit.</div>
+    <div class="mini">Auto‑Risk settings automate stops and take‑profits using your configured thresholds and presets.</div>
+    <div class="mini">When no news is active, prices tend to revert toward the analyst μ with variation described by σ.</div>`;
+
+  modalActions.innerHTML = '';
+  const closeBtn = document.createElement('button');
+  closeBtn.textContent = 'Close';
+  closeBtn.addEventListener('click', () => overlay.style.display = 'none');
+  modalActions.appendChild(closeBtn);
+  overlay.style.display = 'flex';
+}

--- a/src/js/ui/risktools.js
+++ b/src/js/ui/risktools.js
@@ -19,13 +19,13 @@ export function initRiskTools(root, ctx, toast){
   root.innerHTML = `
     <div class="row" style="justify-content:space-between;">
       <div>Auto Risk Tools</div>
-      <label class="mini"><input type="checkbox" id="rt-enabled"> Enabled</label>
+      <label class="mini" title="Apply configured stops and take-profits automatically"><input type="checkbox" id="rt-enabled"> Enabled</label>
     </div>
     <div class="mini">Presets</div>
     <div class="row preset-row">
-      <button class="chip-btn" id="rt-pre-con">Conservative</button>
-      <button class="chip-btn" id="rt-pre-bal">Balanced</button>
-      <button class="chip-btn" id="rt-pre-agg">Aggressive</button>
+      <button class="chip-btn" id="rt-pre-con" title="Tight stops, low exposure">Conservative</button>
+      <button class="chip-btn" id="rt-pre-bal" title="Balanced risk parameters">Balanced</button>
+      <button class="chip-btn" id="rt-pre-agg" title="Wide stops, high exposure">Aggressive</button>
     </div>
     <div class="section">
       <div class="mini section-title">Protection</div>

--- a/src/js/ui/table.js
+++ b/src/js/ui/table.js
@@ -16,7 +16,7 @@ export function buildMarketTable({ tbody, assets, state, onSelect, onBuy, onSell
       <td class="trade">
         <div class="trade-inputs">
           <input class="qty" type="number" min="1" step="1" value="10" id="q-${a.sym}" />
-          ${state.upgrades.leverage>0 ? `<select class="lev" id="lv-${a.sym}"></select>` : `<span class="lock" id="lv-${a.sym}" title="Unlock Leverage in Upgrades">\uD83D\uDD12</span>`}
+          ${state.upgrades.leverage>0 ? `<select class="lev" id="lv-${a.sym}" title="Leverage multiplier"></select>` : `<span class="lock" id="lv-${a.sym}" title="Unlock Leverage in Upgrades">\uD83D\uDD12</span>`}
         </div>
         <div class="trade-buttons">
           <button class="accent" id="b-${a.sym}">Buy</button>

--- a/src/js/ui/upgrades.js
+++ b/src/js/ui/upgrades.js
@@ -44,7 +44,7 @@ export function renderUpgrades(ctx, toast){
         <div>${def.name}</div>
         <div class="mini">${fmt(cost)}</div>
       </div>
-      <div class="mini">${def.desc}</div>
+      <div class="mini" ${def.tip?`title="${def.tip}"`:''}>${def.desc}</div>
       <button id="upg-${def.id}" ${disabled?'disabled':''}>${label}</button>
     </div>`);
   }


### PR DESCRIPTION
## Summary
- Add in-game help modal explaining events, leverage, interest, auto-risk, and μ/σ reversion
- Introduce tooltips for upgrades, risk presets, and leverage selector
- Add Help button to header to access tutorial

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f4312461c832aa72a115f5da3647b