### PR TITLE
Improve accessibility and mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,13 +25,14 @@
       <div class="row" style="justify-content:space-between;align-items:center;margin-bottom:8px;">
         <div class="mini">10‑second days • After‑hours news drives tomorrow</div>
         <div class="row">
-          <button id="startBtn" class="accent">▶ Start Day</button>
-          <button id="saveBtn">Save</button>
-          <button id="helpBtn">Help</button>
-          <button id="resetBtn" class="bad">Hard Reset</button>
+          <button id="startBtn" class="accent" aria-label="Start day">▶ Start Day</button>
+          <button id="saveBtn" aria-label="Save game">Save</button>
+          <button id="helpBtn" aria-label="Help">Help</button>
+          <button id="contrastBtn" aria-label="Toggle high contrast mode" aria-pressed="false">Contrast</button>
+          <button id="resetBtn" class="bad" aria-label="Hard reset game">Hard Reset</button>
         </div>
       </div>
-      <table id="marketTable">
+      <table id="marketTable" aria-label="Market data table">
         <thead>
           <tr>
             <th>Asset</th><th>Price</th><th>Δ</th><th>Analyst</th><th>Holdings</th><th>Value</th><th>Trade</th>
@@ -46,22 +47,28 @@
   <section class="mid-col">
     <div class="card">
       <div class="row" style="justify-content:space-between;">
-        <div>Chart: <b id="chartTitle"></b> <button id="chartToggle">Candles</button></div>
+        <div>Chart: <b id="chartTitle"></b> <button id="chartToggle" aria-label="Toggle chart type">Candles</button></div>
         <div class="row">
           <span class="tag">Prev close = dashed</span>
           <span class="tag">Boundaries = day ends</span>
         </div>
       </div>
-      <div class="chart-wrap"><canvas id="chart" width="820" height="300"></canvas></div>
+      <div class="chart-wrap"><canvas id="chart" width="820" height="300" role="img" aria-label="Asset price chart"></canvas></div>
       <div class="statgrid" id="chartStats"></div>
     </div>
 
     <div class="card">
       <div class="row" style="justify-content:space-between;">
         <div>News & Events — <b id="newsSymbol"></b></div>
-        <div class="mini">Follow the selected asset</div>
+        <div class="row" style="align-items:center;">
+          <div class="mini">Follow the selected asset</div>
+          <button id="majorOnly" class="chip-btn" aria-pressed="false" aria-label="Show major news only">Major</button>
+          <button id="newsCollapse" class="chip-btn" aria-label="Collapse news panel" aria-expanded="true">Collapse</button>
+        </div>
       </div>
-      <div id="newsScroll"><div id="newsTable"></div></div>
+      <div id="newsPanel">
+        <div id="newsScroll"><div id="newsTable"></div></div>
+      </div>
     </div>
   </section>
 
@@ -86,7 +93,7 @@
 
 <!-- Summary Modal -->
 <div class="overlay" id="overlay">
-  <div class="modal" id="modal">
+  <div class="modal" id="modal" role="dialog" aria-modal="true">
     <div id="modalContent"></div>
     <div class="actions" id="modalActions"></div>
   </div>

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -5,7 +5,7 @@
 }
 *{box-sizing:border-box}
 html,body{height:100%;margin:0;background:var(--bg);color:var(--text);
-  font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,"Apple Color Emoji","Segoe UI Emoji")}
+  font:16px/1.4 system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,"Apple Color Emoji","Segoe UI Emoji"}
 .hdr{display:flex;justify-content:space-between;align-items:center;padding:12px 16px;
   background:linear-gradient(180deg,#0f1620,#0c1219);border-bottom:1px solid var(--border);position:sticky;top:0;z-index:5}
 .brand{font-weight:700}.brand small{color:var(--muted);margin-left:8px}
@@ -35,6 +35,10 @@ select.lev{width:70px;background:#0a1118;border:1px solid var(--border);color:va
 button{background:var(--btn);color:var(--text);border:1px solid var(--border);padding:6px 10px;border-radius:8px;cursor:pointer;transition:.15s}
 button:hover{background:var(--btn-hover)} button.accent{background:#12301f;border-color:#1e4230}
 button.bad{background:#2a1313;border-color:#3b1b1b}
+#marketTable tr:focus-visible, button:focus-visible, input:focus-visible, select:focus-visible, .chip-btn:focus-visible{
+  outline:2px solid var(--accent);
+  outline-offset:2px;
+}
 #marketTable th:nth-child(1){width:18%}
 #marketTable th:nth-child(2){width:10%}
 #marketTable th:nth-child(3){width:8%}
@@ -47,6 +51,20 @@ button.bad{background:#2a1313;border-color:#3b1b1b}
 #newsPanel.collapsed{display:none}
 #newsScroll{height:28rem;overflow:auto;padding-right:4px}
 @media (max-width:600px){#newsScroll{height:18rem}}
+body.high-contrast{
+  --bg:#000;
+  --panel:#000;
+  --muted:#fff;
+  --text:#fff;
+  --accent:#0ff;
+  --good:#0f0;
+  --bad:#f00;
+  --warn:#ff0;
+  --btn:#000;
+  --btn-hover:#222;
+  --border:#fff;
+  --table:#000;
+}
 .chart-wrap{height:260px;position:relative}
 canvas{width:100%;height:100%;background:#0a1017;border:1px solid var(--border);border-radius:8px}
 .statgrid{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin-top:8px}
@@ -81,6 +99,13 @@ canvas{width:100%;height:100%;background:#0a1017;border:1px solid var(--border);
 .chip.neg{color:#ffb3b3;border-color:#3a2121}
 .chip-btn{font-size:10px;padding:2px 6px;border:1px solid var(--border);border-radius:999px;background:var(--btn);color:var(--muted);cursor:pointer}
 .chip-btn:hover{background:var(--btn-hover)}
+
+@media (max-width:600px){
+  .hdr{flex-direction:column;align-items:flex-start}
+  .stats{flex-direction:column;gap:4px;align-items:flex-start}
+  .grid{grid-template-columns:1fr;padding:8px}
+  .right-rail{width:100%}
+}
 
 #newsTable tr.major{background:rgba(246,193,119,.08)}
 #newsTable tr.major:hover{background:rgba(246,193,119,.12)}

--- a/src/index.html
+++ b/src/index.html
@@ -25,13 +25,14 @@
       <div class="row" style="justify-content:space-between;align-items:center;margin-bottom:8px;">
         <div class="mini">10‑second days • After‑hours news drives tomorrow</div>
         <div class="row">
-          <button id="startBtn" class="accent">▶ Start Day</button>
-          <button id="saveBtn">Save</button>
-          <button id="helpBtn">Help</button>
-          <button id="resetBtn" class="bad">Hard Reset</button>
+          <button id="startBtn" class="accent" aria-label="Start day">▶ Start Day</button>
+          <button id="saveBtn" aria-label="Save game">Save</button>
+          <button id="helpBtn" aria-label="Help">Help</button>
+          <button id="contrastBtn" aria-label="Toggle high contrast mode" aria-pressed="false">Contrast</button>
+          <button id="resetBtn" class="bad" aria-label="Hard reset game">Hard Reset</button>
         </div>
       </div>
-      <table id="marketTable">
+      <table id="marketTable" aria-label="Market data table">
         <thead>
           <tr>
             <th>Asset</th><th>Price</th><th>Δ</th><th>Analyst</th><th>Holdings</th><th>Value</th><th>Trade</th>
@@ -46,13 +47,13 @@
   <section class="mid-col">
     <div class="card">
       <div class="row" style="justify-content:space-between;">
-        <div>Chart: <b id="chartTitle"></b> <button id="chartToggle">Candles</button></div>
+        <div>Chart: <b id="chartTitle"></b> <button id="chartToggle" aria-label="Toggle chart type">Candles</button></div>
         <div class="row">
           <span class="tag">Prev close = dashed</span>
           <span class="tag">Boundaries = day ends</span>
         </div>
       </div>
-      <div class="chart-wrap"><canvas id="chart" width="820" height="300"></canvas></div>
+      <div class="chart-wrap"><canvas id="chart" width="820" height="300" role="img" aria-label="Asset price chart"></canvas></div>
       <div class="statgrid" id="chartStats"></div>
     </div>
 
@@ -61,8 +62,8 @@
           <div>News & Events — <b id="newsSymbol"></b></div>
           <div class="row" style="align-items:center;">
             <div class="mini">Follow the selected asset</div>
-            <button id="majorOnly" class="chip-btn">Major</button>
-            <button id="newsCollapse" class="chip-btn">Collapse</button>
+            <button id="majorOnly" class="chip-btn" aria-pressed="false" aria-label="Show major news only">Major</button>
+            <button id="newsCollapse" class="chip-btn" aria-label="Collapse news panel" aria-expanded="true">Collapse</button>
           </div>
         </div>
         <div id="newsPanel">
@@ -91,8 +92,8 @@
 <div class="toast-stack" id="toastStack"></div>
 
 <!-- Summary Modal -->
-<div class="overlay" id="overlay">
-  <div class="modal" id="modal">
+  <div class="overlay" id="overlay">
+  <div class="modal" id="modal" role="dialog" aria-modal="true">
     <div id="modalContent"></div>
     <div class="actions" id="modalActions"></div>
   </div>

--- a/src/js/ui/init.js
+++ b/src/js/ui/init.js
@@ -77,6 +77,18 @@ export function initUI(ctx, handlers) {
     drawChart(ctx);
   });
 
+  const contrastBtn = document.getElementById('contrastBtn');
+  if (contrastBtn) {
+    const stored = localStorage.getItem('ttm_contrast') === '1';
+    if (stored) document.body.classList.add('high-contrast');
+    contrastBtn.setAttribute('aria-pressed', stored);
+    contrastBtn.addEventListener('click', () => {
+      const on = document.body.classList.toggle('high-contrast');
+      contrastBtn.setAttribute('aria-pressed', on);
+      localStorage.setItem('ttm_contrast', on ? '1' : '0');
+    });
+  }
+
   document.getElementById('startBtn').addEventListener('click', start);
   document.getElementById('saveBtn').addEventListener('click', save);
   document.getElementById('helpBtn').addEventListener('click', showHelp);

--- a/src/js/ui/newsAssets.js
+++ b/src/js/ui/newsAssets.js
@@ -7,10 +7,12 @@ export function initNewsControls(ctx){
   collapseBtn.addEventListener('click', () => {
     const collapsed = panel.classList.toggle('collapsed');
     collapseBtn.textContent = collapsed ? 'Expand' : 'Collapse';
+    collapseBtn.setAttribute('aria-expanded', String(!collapsed));
   });
   majorBtn.addEventListener('click', () => {
     showMajorOnly = !showMajorOnly;
     majorBtn.classList.toggle('accent', showMajorOnly);
+    majorBtn.setAttribute('aria-pressed', String(showMajorOnly));
     renderAssetNewsTable(ctx);
   });
 }

--- a/src/js/ui/table.js
+++ b/src/js/ui/table.js
@@ -6,6 +6,8 @@ export function buildMarketTable({ tbody, assets, state, onSelect, onBuy, onSell
   tbody.innerHTML = '';
   for (const a of assets){
     const tr = document.createElement('tr'); tr.dataset.sym = a.sym; if (a.isCrypto) tr.dataset.crypto = '1';
+    tr.tabIndex = 0;
+    tr.setAttribute('aria-label', `Select ${a.sym}`);
     tr.innerHTML = `
       <td><b>${a.sym}</b> <span class="mini">• ${a.name}</span></td>
       <td class="price" id="p-${a.sym}"></td>
@@ -31,6 +33,12 @@ export function buildMarketTable({ tbody, assets, state, onSelect, onBuy, onSell
       if (tag === 'BUTTON' || tag === 'INPUT' || tag === 'SELECT') return;
       if (e.target.classList.contains('qty')) return;
       onSelect(a.sym);
+    });
+    tr.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        onSelect(a.sym);
+      }
     });
     if (state.upgrades.leverage>0) {
       const sel = document.getElementById(`lv-${a.sym}`);


### PR DESCRIPTION
## Summary
- add high contrast mode toggle and ARIA labels across UI
- make market table rows keyboard focusable and responsive for mobile
- introduce mobile-friendly styles with larger base fonts and focus outlines

## Testing
- `npm test` *(fails: `/usr/bin/env: 'npm': No such file or directory`)*
- `npm run lint` *(fails: `/usr/bin/env: 'npm': No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_689f449f0058832a95b8a778e2db46d4