### PR TITLE
Fix risk toggle, holdings display, and candlestick history

### DIFF
--- a/src/js/ui/chart.js
+++ b/src/js/ui/chart.js
@@ -10,8 +10,6 @@ export function drawChart(ctx){
   const pad = (max-min)*0.12 + 1e-6; const ymin = min-pad, ymax = max+pad;
   const y = v => h - ((v - ymin) / ((ymax - ymin) || 1)) * h;
   const off = a.history.length - data.length;
-  const dayStart = a.dayBounds[a.dayBounds.length-1] || 0;
-  const relStart = Math.max(0, dayStart - off);
   const step = w/((data.length-1) || 1);
 
   // grid
@@ -29,15 +27,8 @@ export function drawChart(ctx){
   c.globalAlpha=1;
 
   if (ctx.chartMode === 'candles') {
-    // line for previous days
-    if (relStart > 0) {
-      c.lineWidth = 2; c.strokeStyle = "#8ad7a0"; c.beginPath();
-      for(let i=0;i<=relStart;i++){ const px=i*step,py=y(data[i]); if(i===0) c.moveTo(px,py); else c.lineTo(px,py); }
-      c.stroke();
-    }
-    // candles for current day
     const bodyW = step * 0.6;
-    for(let i=Math.max(1, relStart+1); i<data.length; i++){
+    for(let i=1; i<data.length; i++){
       const open=data[i-1], close=data[i];
       const high=Math.max(open,close), low=Math.min(open,close);
       const cx=(i-0.5)*step;

--- a/src/js/ui/risktools.js
+++ b/src/js/ui/risktools.js
@@ -1,5 +1,9 @@
 function loadSaved(){
-  try{ return JSON.parse(localStorage.getItem('ttm_risktools')||'null') || null; }catch{ return null; }
+  try{
+    const cfg = JSON.parse(localStorage.getItem('ttm_risktools')||'null') || null;
+    if (cfg && typeof cfg.enabled === 'string') cfg.enabled = cfg.enabled === 'true';
+    return cfg;
+  }catch{ return null; }
 }
 function save(cfg){
   try {

--- a/src/js/ui/table.js
+++ b/src/js/ui/table.js
@@ -94,7 +94,8 @@ export function renderMarketTable(ctx){
     const vEl = document.getElementById(`v-${a.sym}`);
     if (pEl) pEl.textContent = fmt(price);
     if (cEl) { cEl.textContent = pct(d); cEl.className = 'change ' + (d>=0?'up':'down'); }
-    const have = ctx.state.positions[a.sym] || 0;
+    const margin = (ctx.state.marginPositions||[]).filter(l=>l.sym===a.sym).reduce((s,l)=>s+l.qty,0);
+    const have = (ctx.state.positions[a.sym] || 0) + margin;
     if (hEl) hEl.textContent = have.toLocaleString();
     if (vEl) vEl.textContent = fmt(have * price);
 


### PR DESCRIPTION
## Summary
- ensure risk tools only run when explicitly enabled and account for margin in net worth
- normalize saved risk tool config and display margin positions in holdings table
- extend candlestick rendering across full price history

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f57e8322c832a9935a718342e0362