### PR TITLE
Improve auto-risk rule execution and visibility

### DIFF
--- a/src/js/core/trading.js
+++ b/src/js/core/trading.js
@@ -53,7 +53,7 @@ export function buy(ctx, sym, qty, opts={}){
 }
 
 export function sell(ctx, sym, qty, opts={}){
-  qty = Math.max(1, Math.floor(qty));
+  qty = Math.max(1, Math.ceil(qty));
   const a = ctx.assets.find(x => x.sym === sym);
   if (!a) return 0;
   let remaining = qty;

--- a/src/js/test/legacy.test.js
+++ b/src/js/test/legacy.test.js
@@ -6,6 +6,7 @@ import './options.spec.js';
 import './crypto.spec.js';
 import './summary.spec.js';
 import './events.spec.js';
+import './risk.spec.js';
 
 test('legacy specs pass', () => {
   expect(true).toBe(true);

--- a/src/js/test/risk.spec.js
+++ b/src/js/test/risk.spec.js
@@ -1,0 +1,72 @@
+import assert from 'assert';
+import { createInitialState } from '../core/state.js';
+import { evaluateRisk } from '../core/risk.js';
+import { ASSET_DEFS } from '../config.js';
+
+(function testHardStopPriority(){
+  const ctx = createInitialState(ASSET_DEFS.slice(0,1));
+  const sym = ctx.assets[0].sym;
+  ctx.state.positions[sym] = 10;
+  ctx.state.costBasis[sym] = {qty:10, avg:100};
+  ctx.assets[0].price = 80;
+  ctx.state.riskTools = { enabled:true, hardStop:0.1, trailing:0.05, stopSellFrac:1, posCap:1 };
+  const logs=[];
+  evaluateRisk(ctx, { log:m=>logs.push(m) });
+  assert.strictEqual(ctx.state.positions[sym], 0, 'hard stop sold all');
+  assert(logs.some(m=>/Auto.*STOP/.test(m)), 'stop logged');
+  assert.strictEqual(ctx.riskTrack[sym].lastRule, 'STOP', 'last rule STOP');
+})();
+
+(function testTrailing(){
+  const ctx = createInitialState(ASSET_DEFS.slice(0,1));
+  const sym = ctx.assets[0].sym;
+  ctx.state.positions[sym] = 10;
+  ctx.state.costBasis[sym] = {qty:10, avg:100};
+  ctx.assets[0].price = 120;
+  ctx.state.riskTools = { enabled:true, hardStop:0.3, trailing:0.1, stopSellFrac:1, posCap:1 };
+  evaluateRisk(ctx); // set peak
+  const logs=[];
+  ctx.assets[0].price = 105;
+  evaluateRisk(ctx, { log:m=>logs.push(m) });
+  assert.strictEqual(ctx.state.positions[sym], 0, 'trailing sold all');
+  assert(logs.some(m=>/Auto.*TRAIL/.test(m)), 'trail logged');
+  assert.strictEqual(ctx.riskTrack[sym].lastRule, 'TRAIL', 'last rule TRAIL');
+})();
+
+(function testTPLadderStage(){
+  const ctx = createInitialState(ASSET_DEFS.slice(0,1));
+  const sym = ctx.assets[0].sym;
+  ctx.state.positions[sym] = 10;
+  ctx.state.costBasis[sym] = {qty:10, avg:100};
+  ctx.state.riskTools = { enabled:true, tp1:0.1, tp1Frac:0.5, tp2:0.2, tp2Frac:0.5, trailing:1, hardStop:1, posCap:1 };
+  const logs=[];
+  ctx.assets[0].price = 150;
+  evaluateRisk(ctx, { log:m=>logs.push(m) });
+  assert.strictEqual(ctx.state.positions[sym], 5, 'tp1 sold half');
+  assert.strictEqual(ctx.riskTrack[sym].lastTP, 1, 'stage 1');
+  assert(logs.filter(m=>/Auto.*TP/.test(m)).length === 1, 'only one tp log');
+  ctx.assets[0].price = 200;
+  evaluateRisk(ctx, { log:m=>logs.push(m) });
+  assert.strictEqual(ctx.state.positions[sym], 2, 'tp2 sold');
+  assert.strictEqual(ctx.riskTrack[sym].lastTP, 2, 'stage 2');
+  assert(logs.filter(m=>/Auto.*TP/.test(m)).length === 2, 'two tp logs');
+})();
+
+(function testPositionCap(){
+  const ctx = createInitialState(ASSET_DEFS.slice(0,1));
+  const sym = ctx.assets[0].sym;
+  ctx.state.positions[sym] = 10;
+  ctx.state.costBasis[sym] = {qty:10, avg:100};
+  ctx.state.cash = 0; ctx.state.debt = 0;
+  ctx.state.riskTools = { enabled:true, posCap:0.25, trailing:1, hardStop:1 };
+  const logs=[];
+  evaluateRisk(ctx, { log:m=>logs.push(m) });
+  assert.strictEqual(ctx.state.positions[sym], 2, 'trimmed to cap');
+  assert(logs.some(m=>/Auto.*CAP/.test(m)), 'cap logged');
+  assert.strictEqual(ctx.riskTrack[sym].lastRule, 'CAP', 'last rule CAP');
+  logs.length = 0;
+  evaluateRisk(ctx, { log:m=>logs.push(m) });
+  assert.strictEqual(logs.length, 0, 'no repeat');
+})();
+
+console.log('risk.spec passed');

--- a/src/js/ui/init.js
+++ b/src/js/ui/init.js
@@ -105,6 +105,7 @@ export function initUI(ctx, handlers) {
     renderPortfolio(ctx);
     renderUpgrades(ctx, toast);
     ctx.renderMarketTabs();
+    ctx.renderRiskStats?.();
   }
   ctx.renderAll = renderAll;
 

--- a/src/js/ui/modal.js
+++ b/src/js/ui/modal.js
@@ -62,6 +62,28 @@ export function showSummary(summary, onNext){
   table.appendChild(tbody);
   modalContent.appendChild(table);
 
+  const rtable = document.createElement('table');
+  rtable.innerHTML = `<thead><tr>
+    <th>Asset</th><th>Basis</th><th>Peak</th><th>Ret%</th><th>DD%</th><th>Next TP</th><th>Last Rule</th>
+  </tr></thead>`;
+  const rtbody = document.createElement('tbody');
+  for (const r of rows){
+    const tr = document.createElement('tr');
+    const tdAsset = document.createElement('td'); tdAsset.textContent = r.sym;
+    const tdBasis = document.createElement('td'); tdBasis.textContent = fmt(r.basis);
+    const tdPeak = document.createElement('td'); tdPeak.textContent = fmt(r.peak);
+    const tdRet = document.createElement('td'); tdRet.textContent = `${(r.ret*100).toFixed(1)}%`;
+    tdRet.className = r.ret >= 0 ? 'up' : 'down';
+    const tdDD = document.createElement('td'); tdDD.textContent = `${(r.draw*100).toFixed(1)}%`;
+    tdDD.className = r.draw >= 0 ? 'up' : 'down';
+    const tdNext = document.createElement('td'); tdNext.textContent = r.nextTP!=null ? `${Math.round(r.nextTP*100)}%` : '—';
+    const tdLast = document.createElement('td'); tdLast.textContent = r.lastRule || '—';
+    tr.append(tdAsset, tdBasis, tdPeak, tdRet, tdDD, tdNext, tdLast);
+    rtbody.appendChild(tr);
+  }
+  rtable.appendChild(rtbody);
+  modalContent.appendChild(rtable);
+
   modalActions.innerHTML = '';
   const nextBtn = document.createElement('button'); nextBtn.className='accent'; nextBtn.textContent='Start Next Day ▶';
   nextBtn.addEventListener('click', onNext);


### PR DESCRIPTION
## Summary
- Prioritize hard stops, then trailing stops, take-profit stages, and position caps while recording the last rule fired
- Round risk-based sell quantities up to avoid underselling and trim positions deterministically
- Expose per-asset risk stats and last auto-rule in the risk tools panel and day-end summary

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f6b195ccc832abe392c9241ebe62a