### PR TITLE
fix: prevent UI crashes when elements missing

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -30,6 +30,11 @@ const btnHardReset = $('#btn-hard-reset');
 const chartCanvas = $('#price-chart');
 let lastNet = netWorth(state);
 
+// Safely set textContent when element exists
+const setText = (el, txt) => {
+  if (el) el.textContent = txt;
+};
+
 // --- Utils
 const fmtMoney = (n) =>
   (n < 0 ? '-$' : '$') + Math.abs(n).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
@@ -41,14 +46,14 @@ const fmtCompact = (n) =>
 function startDay() {
   if (tickTimer) return;
   dayLeft = state.secondsPerDay;
-  btnStart.textContent = '⏸ Pause';
+  if (btnStart) btnStart.textContent = '⏸ Pause';
   tickTimer = setInterval(tick, 1000);
 }
 
 function pauseDay() {
   clearInterval(tickTimer);
   tickTimer = null;
-  btnStart.textContent = '▶ Start Day';
+  if (btnStart) btnStart.textContent = '▶ Start Day';
 }
 
 function tick() {
@@ -61,7 +66,7 @@ function tick() {
 
   // 3) countdown
   dayLeft -= 1;
-  hudTime.textContent = `${dayLeft}s`;
+  setText(hudTime, `${dayLeft}s`);
 
   if (dayLeft <= 0) endOfDay();
 }
@@ -88,13 +93,13 @@ function endOfDay() {
   persist(state);
 
   // modal summary
-  eodDay.textContent = state.day;
-  eodNetChange.textContent = `${delta >= 0 ? '+' : ''}${fmtMoney(delta)} (Net: ${fmtCompact(nw)})`;
-  eodNetChange.className = delta >= 0 ? 'pos' : 'neg';
-  eodBest.textContent = `${best.sym} ${best.change >= 0 ? '▲' : '▼'} ${fmtMoney(best.change)}`;
-  eodWorst.textContent = `${worst.sym} ${worst.change >= 0 ? '▲' : '▼'} ${fmtMoney(worst.change)}`;
+  setText(eodDay, state.day);
+  setText(eodNetChange, `${delta >= 0 ? '+' : ''}${fmtMoney(delta)} (Net: ${fmtCompact(nw)})`);
+  if (eodNetChange) eodNetChange.className = delta >= 0 ? 'pos' : 'neg';
+  setText(eodBest, `${best.sym} ${best.change >= 0 ? '▲' : '▼'} ${fmtMoney(best.change)}`);
+  setText(eodWorst, `${worst.sym} ${worst.change >= 0 ? '▲' : '▼'} ${fmtMoney(worst.change)}`);
 
-  if (typeof eodModal.showModal === 'function') eodModal.showModal();
+  if (eodModal && typeof eodModal.showModal === 'function') eodModal.showModal();
   else alert(`Day ${state.day} • Net change: ${delta >= 0 ? '+' : ''}${fmtMoney(delta)}`);
 }
 
@@ -102,12 +107,12 @@ function refreshHUD() {
   const assetsValue = state.assets.reduce((s, a) => s + a.qty * a.price, 0);
   const nw = netWorth(state);
 
-  hudDay.textContent = state.day;
-  hudCash.textContent = fmtMoney(state.cash);
-  hudDebt.textContent = fmtMoney(state.debt);
-  hudAssets.textContent = fmtMoney(assetsValue);
-  hudNet.textContent = fmtMoney(nw);
-  hudRisk.textContent = `${riskPct(state)}%`;
+  setText(hudDay, state.day);
+  setText(hudCash, fmtMoney(state.cash));
+  setText(hudDebt, fmtMoney(state.debt));
+  setText(hudAssets, fmtMoney(assetsValue));
+  setText(hudNet, fmtMoney(nw));
+  setText(hudRisk, `${riskPct(state)}%`);
 
   drawChart(chartCanvas, state);
 }
@@ -184,23 +189,26 @@ function drawChart(canvas, s) {
 }
 
 // --- Buttons & wiring
-btnStart.addEventListener('click', () => (tickTimer ? pauseDay() : startDay()));
-btnSave.addEventListener('click', () => persist(state));
-btnHelp.addEventListener('click', () =>
-  alert('Buy low, sell high, sip coffee. Days are short; news hits after hours. Autosave at day end.')
-);
-btnContrast.addEventListener('click', () => {
-  document.documentElement.classList.toggle('high-contrast');
-});
-btnHardReset.addEventListener('click', () => {
-  if (confirm('Hard reset and clear local save?')) {
-    pauseDay();
-    state = hardReset();
-    lastNet = netWorth(state);
-    refreshHUD();
-    renderTable(state, onSelectAsset, onTrade);
-  }
-});
+btnStart && btnStart.addEventListener('click', () => (tickTimer ? pauseDay() : startDay()));
+btnSave && btnSave.addEventListener('click', () => persist(state));
+btnHelp &&
+  btnHelp.addEventListener('click', () =>
+    alert('Buy low, sell high, sip coffee. Days are short; news hits after hours. Autosave at day end.')
+  );
+btnContrast &&
+  btnContrast.addEventListener('click', () => {
+    document.documentElement.classList.toggle('high-contrast');
+  });
+btnHardReset &&
+  btnHardReset.addEventListener('click', () => {
+    if (confirm('Hard reset and clear local save?')) {
+      pauseDay();
+      state = hardReset();
+      lastNet = netWorth(state);
+      refreshHUD();
+      renderTable(state, onSelectAsset, onTrade);
+    }
+  });
 
 // Table event delegation
 bindTableHandlers(onSelectAsset, onTrade);


### PR DESCRIPTION
## Summary
- avoid crashes when DOM elements are missing by checking before access
- safely update text content via helper

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f8ad1d188832ab76ee5e3316be083