### PR TITLE
Refactor market table for accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,14 +32,7 @@
           <button id="resetBtn" class="bad" aria-label="Hard reset game">Hard Reset</button>
         </div>
       </div>
-      <table id="marketTable" aria-label="Market data table">
-        <thead>
-          <tr>
-            <th>Asset</th><th>Price</th><th>Δ</th><th>Analyst</th><th>Holdings</th><th>Value</th><th>Trade</th>
-          </tr>
-        </thead>
-        <tbody id="tbody"></tbody>
-      </table>
+      <table id="marketTable" aria-label="Market data table"></table>
     </div>
 
   </section>

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -24,6 +24,8 @@ table{width:100%;border-collapse:separate;border-spacing:0}
 thead th{position:sticky;top:0;background:var(--table);color:var(--muted);text-align:left;padding:8px;border-bottom:1px solid var(--border)}
 tbody td{padding:8px;border-bottom:1px dashed rgba(255,255,255,.06);vertical-align:middle}
 tr:hover{background:#0e141d}
+#marketTable tr.selected{background:rgba(104,211,145,.15)}
+body.high-contrast #marketTable tr.selected{background:var(--accent);color:#000}
 .price,.change,.holdings,.value{font-variant-numeric:tabular-nums}
 .change.up{color:var(--good)}.change.down{color:var(--bad)}
 td.trade{padding:8px}
@@ -39,13 +41,15 @@ button.bad{background:#2a1313;border-color:#3b1b1b}
   outline:2px solid var(--accent);
   outline-offset:2px;
 }
-#marketTable th:nth-child(1){width:18%}
-#marketTable th:nth-child(2){width:10%}
-#marketTable th:nth-child(3){width:8%}
-#marketTable th:nth-child(4){width:14%}
-#marketTable th:nth-child(5){width:10%}
+#marketTable tr.selected:focus-visible{outline:2px solid var(--accent)}
+#marketTable th:nth-child(1){width:12%}
+#marketTable th:nth-child(2){width:18%}
+#marketTable th:nth-child(3){width:10%}
+#marketTable th:nth-child(4){width:8%}
+#marketTable th:nth-child(5){width:14%}
 #marketTable th:nth-child(6){width:10%}
-#marketTable th:nth-child(7){width:30%}
+#marketTable th:nth-child(7){width:10%}
+#marketTable th:nth-child(8){width:18%}
 .market-col,.mid-col,.right-rail{display:grid;gap:16px}
 .right-rail{width:320px}
 #newsPanel.collapsed{display:none}
@@ -100,6 +104,16 @@ canvas{width:100%;height:100%;background:#0a1017;border:1px solid var(--border);
 .chip.neg{color:#ffb3b3;border-color:#3a2121}
 .chip-btn{font-size:10px;padding:2px 6px;border:1px solid var(--border);border-radius:999px;background:var(--btn);color:var(--muted);cursor:pointer}
 .chip-btn:hover{background:var(--btn-hover)}
+
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0}
+
+@media (max-width:800px){
+  #marketTable th:nth-child(5),#marketTable td:nth-child(5){display:none}
+}
+@media (max-width:600px){
+  #marketTable th:nth-child(7),#marketTable td:nth-child(7){display:none}
+  #marketTable th:nth-child(6),#marketTable td:nth-child(6){display:none}
+}
 
 @media (max-width:600px){
   .hdr{flex-direction:column;align-items:flex-start}

--- a/src/index.html
+++ b/src/index.html
@@ -32,14 +32,7 @@
           <button id="resetBtn" class="bad" aria-label="Hard reset game">Hard Reset</button>
         </div>
       </div>
-      <table id="marketTable" aria-label="Market data table">
-        <thead>
-          <tr>
-            <th>Asset</th><th>Price</th><th>Δ</th><th>Analyst</th><th>Holdings</th><th>Value</th><th>Trade</th>
-          </tr>
-        </thead>
-        <tbody id="tbody"></tbody>
-      </table>
+      <table id="marketTable" aria-label="Market data table"></table>
     </div>
 
   </section>

--- a/src/js/ui/init.js
+++ b/src/js/ui/init.js
@@ -17,9 +17,10 @@ export function initUI(ctx, handlers) {
   const log = msg => console.log(msg);
 
   function rebuildMarketTable() {
+    const assets = ctx.assets.filter(a => ctx.marketTab === 'crypto' ? a.isCrypto && ctx.state.upgrades.crypto : !a.isCrypto);
     buildMarketTable({
-      tbody: document.getElementById('tbody'),
-      assets: ctx.assets,
+      table: document.getElementById('marketTable'),
+      assets,
       state: ctx.state,
       onSelect: sym => {
         ctx.selected = sym;
@@ -46,6 +47,7 @@ export function initUI(ctx, handlers) {
   const tabs = document.createElement('div');
   tabs.id = 'marketTabs';
   tabs.className = 'row tabs';
+  tabs.setAttribute('role', 'tablist');
   const card = document.querySelector('.market-col .card');
   card.insertBefore(tabs, document.getElementById('marketTable'));
 
@@ -54,9 +56,14 @@ export function initUI(ctx, handlers) {
     const mk = (id, label) => {
       const btn = document.createElement('button');
       btn.textContent = label;
+      btn.setAttribute('role', 'tab');
+      btn.id = `tab-${id}`;
+      btn.setAttribute('aria-controls', 'marketTable');
+      btn.setAttribute('aria-selected', ctx.marketTab === id);
       if (ctx.marketTab === id) btn.classList.add('accent');
       btn.addEventListener('click', () => {
         ctx.marketTab = id;
+        rebuildMarketTable();
         renderMarketTable(ctx);
         renderTabs();
       });


### PR DESCRIPTION
## Summary
- Build market table via DOM APIs with explicit headers, accessible labels, and arrow-key row navigation
- Expose stock/crypto tabs with ARIA attributes and rebuild table per tab
- Improve table styling with responsive column hiding, high-contrast row highlight, and screen-reader utility class

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fa123de88832a9a3e29cb4590f902