### PR TITLE
Refine market table and insider tip effects

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -29,11 +29,17 @@ body.high-contrast #marketTable tr.selected{background:var(--accent);color:#000}
 .price,.change,.holdings,.value{font-variant-numeric:tabular-nums}
 .change.up{color:var(--good)}.change.down{color:var(--bad)}
 td.trade{padding:8px}
-.trade-inputs{display:flex;gap:6px;align-items:center;margin-bottom:4px}
-.trade-buttons{display:flex;flex-wrap:wrap;gap:6px}
-input.qty{width:78px;background:#0a1118;border:1px solid var(--border);color:var(--text);border-radius:6px;padding:6px 8px}
-select.lev{width:70px;background:#0a1118;border:1px solid var(--border);color:var(--text);border-radius:6px;padding:6px 4px}
+.trade-bar{display:none;gap:6px;align-items:center}
+tr:hover .trade-bar,
+tr:focus-within .trade-bar,
+tr.selected .trade-bar{display:flex}
+input.qty{width:60px;background:#0a1118;border:1px solid var(--border);color:var(--text);border-radius:6px;padding:4px 6px;font-size:12px}
+select.lev{width:60px;background:#0a1118;border:1px solid var(--border);color:var(--text);border-radius:6px;padding:4px 2px;font-size:12px}
 .lock{color:var(--muted);font-size:16px}
+.tip-indicator{display:none;font-size:12px;margin-left:4px}
+.tip-indicator.bull{color:var(--accent)}
+.tip-indicator.bear{color:var(--bad)}
+.trade-bar button{padding:4px 6px;font-size:12px}
 button{background:var(--btn);color:var(--text);border:1px solid var(--border);padding:6px 10px;border-radius:8px;cursor:pointer;transition:.15s}
 button:hover{background:var(--btn-hover)} button.accent{background:#12301f;border-color:#1e4230}
 button.bad{background:#2a1313;border-color:#3b1b1b}
@@ -42,14 +48,13 @@ button.bad{background:#2a1313;border-color:#3b1b1b}
   outline-offset:2px;
 }
 #marketTable tr.selected:focus-visible{outline:2px solid var(--accent)}
-#marketTable th:nth-child(1){width:12%}
-#marketTable th:nth-child(2){width:18%}
-#marketTable th:nth-child(3){width:10%}
-#marketTable th:nth-child(4){width:8%}
-#marketTable th:nth-child(5){width:14%}
-#marketTable th:nth-child(6){width:10%}
-#marketTable th:nth-child(7){width:10%}
-#marketTable th:nth-child(8){width:18%}
+#marketTable th:nth-child(1){width:16%}
+#marketTable th:nth-child(2){width:10%}
+#marketTable th:nth-child(3){width:8%}
+#marketTable th:nth-child(4){width:14%}
+#marketTable th:nth-child(5){width:12%}
+#marketTable th:nth-child(6){width:12%}
+#marketTable th:nth-child(7){width:28%}
 .market-col,.mid-col,.right-rail{display:grid;gap:16px}
 .right-rail{width:320px}
 #newsPanel.collapsed{display:none}
@@ -108,11 +113,11 @@ canvas{width:100%;height:100%;background:#0a1017;border:1px solid var(--border);
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0}
 
 @media (max-width:800px){
-  #marketTable th:nth-child(5),#marketTable td:nth-child(5){display:none}
+  #marketTable th:nth-child(4),#marketTable td:nth-child(4){display:none}
 }
 @media (max-width:600px){
-  #marketTable th:nth-child(7),#marketTable td:nth-child(7){display:none}
   #marketTable th:nth-child(6),#marketTable td:nth-child(6){display:none}
+  #marketTable th:nth-child(5),#marketTable td:nth-child(5){display:none}
 }
 
 @media (max-width:600px){

--- a/src/js/ui/insight.js
+++ b/src/js/ui/insight.js
@@ -5,14 +5,19 @@ export function renderInsight(ctx){
   const line = document.getElementById('analystLine');
   const t=a.analyst?.tone||'Neutral', cls=a.analyst?.cls||'neu', conf=Math.round((a.analyst?.conf||0.5)*100);
   const od=a.outlookDetail||{gMu:0, evMu:0, evDem:0, valuation:0, streakMR:0, demandTerm:0};
-  line.innerHTML = [
+  const parts = [
     `<span class="analyst ${cls}">${t}</span>`,
     `<span class="mini">Conf ${conf}%</span>`,
     `<span class="tag">Events μ: ${((od.evMu||0)*CFG.DAY_TICKS*100).toFixed(1)}bp</span>`,
     `<span class="tag">Event demand: ${((od.evDem||0)*100).toFixed(1)}%</span>`,
     `<span class="tag">Valuation: ${((od.valuation||0)*100).toFixed(1)}bp</span>`,
     `<span class="tag">Streak MR: ${((od.streakMR||0)*100).toFixed(1)}bp</span>`
-  ].join(' ');
+  ];
+  if (ctx.state.insiderTip && ctx.state.insiderTip.sym === a.sym && ctx.state.insiderTip.daysLeft > 0) {
+    const tip = ctx.state.insiderTip;
+    parts.push(`<span class="tag" title="μ ${(tip.mu*100).toFixed(2)}% σ ${(tip.sigma*100).toFixed(2)}%">Tip ${tip.bias>0?'Bullish':'Bearish'} ${tip.daysLeft}d</span>`);
+  }
+  line.innerHTML = parts.join(' ');
 
   const news = document.getElementById('assetNews');
   const list = (ctx.newsByAsset && ctx.newsByAsset[a.sym]) || [];

--- a/src/js/ui/upgrades.js
+++ b/src/js/ui/upgrades.js
@@ -43,7 +43,9 @@ export function renderUpgrades(ctx, toast){
       else if(cost > ctx.state.cash) reason = 'Insufficient cash';
       else if(tip) reason = 'Tip active';
       else if(cd > 0) reason = `Cooldown ${cd}d`;
-      label = tip ? `Active ${tip.bias>0?'Bullish':'Bearish'} (${tip.daysLeft}d)` : 'Buy Tip';
+      if (tip) label = `Active ${tip.bias>0?'Bullish':'Bearish'} (${tip.daysLeft}d)`;
+      else if (cd > 0) label = `Cooldown ${cd}d`;
+      else label = 'Buy Tip';
     } else {
       const owned = ctx.state.upgrades[def.id];
       disabled = ctx.day.active || cost > ctx.state.cash || (def.id !== 'leverage' && owned);


### PR DESCRIPTION
## Summary
- Rebuilt market table with leaner columns and a hover-revealed trade bar for compact, keyboard-friendly interactions.
- Surface insider tip activity in both table and insight panel, plus apply tip drift/volatility directly in pricing.
- Disable insider upgrade during active tips or cooldowns and add test to verify price bias from tips.

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fa8152420832a8fa9678d860d0165