### PR TITLE
Refine market table layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,8 +21,8 @@
 
 <div class="grid">
   <section class="market-col">
-    <div class="card">
-      <div class="row" style="justify-content:space-between;align-items:center;margin-bottom:8px;">
+    <div class="card market-panel">
+      <div class="market-header row">
         <div class="mini">10‑second days • After‑hours news drives tomorrow</div>
         <div class="row">
           <button id="startBtn" class="accent" aria-label="Start day">▶ Start Day</button>
@@ -34,7 +34,6 @@
       </div>
       <table id="marketTable" aria-label="Market data table"></table>
     </div>
-
   </section>
 
   <section class="mid-col">

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -15,6 +15,8 @@ html,body{height:100%;margin:0;background:var(--bg);color:var(--text);
 .grid{display:grid;grid-template-columns:3fr 1fr 320px;gap:16px;padding:16px;max-width:1500px;margin:0 auto}
 @media (max-width:1100px){.grid{grid-template-columns:1fr}}
 .card{background:var(--panel);border:1px solid var(--border);border-radius:10px;padding:12px}
+.card.market-panel{padding:0;overflow:hidden}
+.market-header{justify-content:space-between;align-items:center;padding:12px;border-bottom:1px solid var(--border)}
 .row{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
 .mini{font-size:12px;color:var(--muted)}
 .tag{font-size:11px;padding:2px 6px;border:1px solid var(--border);border-radius:999px;color:var(--muted)}
@@ -22,14 +24,14 @@ html,body{height:100%;margin:0;background:var(--bg);color:var(--text);
 #marketTable{width:100%;border-collapse:separate;border-spacing:0;table-layout:fixed}
 table{width:100%;border-collapse:separate;border-spacing:0}
 thead th{position:sticky;top:0;background:var(--table);color:var(--muted);text-align:left;padding:8px;border-bottom:1px solid var(--border)}
-tbody td{padding:8px;border-bottom:1px dashed rgba(255,255,255,.06);vertical-align:middle}
+tbody td{padding:6px;border-bottom:1px dashed rgba(255,255,255,.06);vertical-align:middle}
 tr:hover{background:#0e141d}
 #marketTable tr.selected{background:rgba(104,211,145,.15)}
 body.high-contrast #marketTable tr.selected{background:var(--accent);color:#000}
 .price,.change,.holdings,.value{font-variant-numeric:tabular-nums}
 .change.up{color:var(--good)}.change.down{color:var(--bad)}
 td.trade{padding:8px}
-.trade-bar{display:none;gap:6px;align-items:center;flex-wrap:wrap}
+.trade-bar{display:none;gap:4px;align-items:center}
 tr:hover .trade-bar,
 tr:focus-within .trade-bar,
 tr.selected .trade-bar{display:flex}
@@ -39,7 +41,7 @@ select.lev{width:60px;background:#0a1118;border:1px solid var(--border);color:va
 .tip-indicator{display:none;font-size:12px;margin-left:4px}
 .tip-indicator.bull{color:var(--accent)}
 .tip-indicator.bear{color:var(--bad)}
-.trade-bar button{padding:4px 6px;font-size:12px}
+.trade-bar button{padding:3px 5px;font-size:12px}
 button{background:var(--btn);color:var(--text);border:1px solid var(--border);padding:6px 10px;border-radius:8px;cursor:pointer;transition:.15s}
 button:hover{background:var(--btn-hover)} button.accent{background:#12301f;border-color:#1e4230}
 button.bad{background:#2a1313;border-color:#3b1b1b}
@@ -54,7 +56,7 @@ button.bad{background:#2a1313;border-color:#3b1b1b}
 #marketTable th:nth-child(4){width:13%}
 #marketTable th:nth-child(5){width:11%}
 #marketTable th:nth-child(6){width:10%}
-#marketTable th:nth-child(7){width:35%}
+#marketTable th:nth-child(7){width:30%}
 .market-col,.mid-col,.right-rail{display:grid;gap:16px}
 .right-rail{width:320px}
 #newsPanel.collapsed{display:none}

--- a/src/index.html
+++ b/src/index.html
@@ -21,8 +21,8 @@
 
 <div class="grid">
   <section class="market-col">
-    <div class="card">
-      <div class="row" style="justify-content:space-between;align-items:center;margin-bottom:8px;">
+    <div class="card market-panel">
+      <div class="market-header row">
         <div class="mini">10‑second days • After‑hours news drives tomorrow</div>
         <div class="row">
           <button id="startBtn" class="accent" aria-label="Start day">▶ Start Day</button>
@@ -34,7 +34,6 @@
       </div>
       <table id="marketTable" aria-label="Market data table"></table>
     </div>
-
   </section>
 
   <section class="mid-col">


### PR DESCRIPTION
## Summary
- Wrap market table in a zero-padding card so it aligns with the page margin
- Add flex header and compact trade-bar to reduce row height
- Adjust action column and button sizing for tighter spacing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fb1fb6ecc832a8f893842198e6a69