### PR TITLE
Streamline Asset Insight and categorize demand

### DIFF
--- a/src/js/ui/chart.js
+++ b/src/js/ui/chart.js
@@ -176,10 +176,16 @@ export function drawChart(ctx) {
   // stats panel
   const stats = document.getElementById('chartStats');
   stats.innerHTML = '';
+  const demandVal = a.localDemand;
+  let demandCat;
+  if (demandVal < 0.9) demandCat = 'Low';
+  else if (demandVal < 1.1) demandCat = 'Medium';
+  else if (demandVal < 1.5) demandCat = 'High';
+  else demandCat = 'Extreme';
   const rows = [
     ['Supply', a.supply.toLocaleString()],
     ['Market Cap', fmt(last * a.supply)],
-    ['Local Demand', a.localDemand.toFixed(2) + ` (ev ${(a.evDemandBias >= 0 ? '+' : '')}${a.evDemandBias.toFixed(2)})`],
+    ['Local Demand', `${demandCat} (ev ${(a.evDemandBias >= 0 ? '+' : '')}${a.evDemandBias.toFixed(2)})`],
     ['Fair Value', fmt(a.fair)],
     ['Tomorrow (μ ± σ)', `${((a.outlook?.mu || 0) * 100).toFixed(2)}% ± ${((a.outlook?.sigma || a.daySigma || 0) * 100).toFixed(2)}%`],
     ['Expected Open Gap', `${(a.outlook?.gap || 0) >= 0 ? '+' : ''}${((a.outlook?.gap || 0) * 100).toFixed(1)}%`]

--- a/src/js/ui/insight.js
+++ b/src/js/ui/insight.js
@@ -5,19 +5,15 @@ export function renderInsight(ctx){
   const line = document.getElementById('analystLine');
   const t=a.analyst?.tone||'Neutral', cls=a.analyst?.cls||'neu', conf=Math.round((a.analyst?.conf||0.5)*100);
   const od=a.outlookDetail||{gMu:0, evMu:0, evDem:0, valuation:0, streakMR:0, demandTerm:0};
-  const parts = [
-    `<span class="analyst ${cls}">${t}</span>`,
-    `<span class="mini">Conf ${conf}%</span>`,
-    `<span class="tag">Events μ: ${((od.evMu||0)*CFG.DAY_TICKS*100).toFixed(1)}bp</span>`,
-    `<span class="tag">Event demand: ${((od.evDem||0)*100).toFixed(1)}%</span>`,
-    `<span class="tag">Valuation: ${((od.valuation||0)*100).toFixed(1)}bp</span>`,
-    `<span class="tag">Streak MR: ${((od.streakMR||0)*100).toFixed(1)}bp</span>`
-  ];
+  const eventCount = (ctx.market.tomorrow || []).filter(ev => ev.scope === 'global' || ev.sym === a.sym).length;
+  const netBias = (od.evMu||0)*CFG.DAY_TICKS*100;
+  const detailTip = `Event μ: ${((od.evMu||0)*CFG.DAY_TICKS*100).toFixed(1)}%\nEvent demand: ${((od.evDem||0)*100).toFixed(1)}%\nValuation: ${((od.valuation||0)*100).toFixed(1)}%\nStreak MR: ${((od.streakMR||0)*100).toFixed(1)}%`;
+  let summary = `Analyst: <span class="analyst ${cls}">${t}</span>, Confidence: ${conf}%, <span title="${detailTip}">Upcoming events: ${eventCount} (net bias ${(netBias>=0?'+':'') + netBias.toFixed(1)}%)</span>`;
   if (ctx.state.insiderTip && ctx.state.insiderTip.sym === a.sym && ctx.state.insiderTip.daysLeft > 0) {
     const tip = ctx.state.insiderTip;
-    parts.push(`<span class="tag" title="μ ${(tip.mu*100).toFixed(2)}% σ ${(tip.sigma*100).toFixed(2)}%">Tip ${tip.bias>0?'Bullish':'Bearish'} ${tip.daysLeft}d</span>`);
+    summary += ` <span class="tag" title="μ ${(tip.mu*100).toFixed(2)}% σ ${(tip.sigma*100).toFixed(2)}%">Tip ${tip.bias>0?'Bullish':'Bearish'} ${tip.daysLeft}d</span>`;
   }
-  line.innerHTML = parts.join(' ');
+  line.innerHTML = summary;
 
   const news = document.getElementById('assetNews');
   const list = (ctx.newsByAsset && ctx.newsByAsset[a.sym]) || [];


### PR DESCRIPTION
## Summary
- Condense Asset Insight line into a concise summary with analyst tone, confidence, upcoming event count, and net bias, with detailed metrics in a tooltip.
- Map local demand values to semantic categories (Low/Medium/High/Extreme) and display underlying event demand bias.

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fb795f680832abed57ab87f1b0494