### PR TITLE
Persist risk rule tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,4 @@
 - Candlestick chart with intraday and multi‑day timeframes plus market cap stats.
 - Insider tips now highlight the affected asset and apply visible drift for their duration.
 - Auto‑risk tools respect a one‑tick grace period after buying to prevent premature triggers.
-- Save data persists insider tips, risk settings, and last trade ticks for seamless reloads.
+- Save data persists insider tips, risk settings, last trade ticks, and risk rule tracking for seamless reloads.

--- a/src/js/persistence.js
+++ b/src/js/persistence.js
@@ -2,7 +2,7 @@ import { save as saveGame, load as loadGame, SAVE_VERSION } from './core/persist
 
 export function setupPersistence(ctx, log = console.log) {
   function save() {
-    saveGame(ctx.state, ctx.market, ctx.assets, SAVE_VERSION);
+    saveGame(ctx.state, ctx.market, ctx.assets, ctx.riskTrack, SAVE_VERSION);
     log('Save complete.');
   }
   function load() {

--- a/src/js/test/persist.test.js
+++ b/src/js/test/persist.test.js
@@ -1,14 +1,17 @@
-import { save, load } from '../core/persist.js';
+import { save, load, SAVE_VERSION } from '../core/persist.js';
 import { createInitialState } from '../core/state.js';
 import { ASSET_DEFS } from '../config.js';
 
-test('save and load round trip state', () => {
+test('save and load round trip state and riskTrack', () => {
   const ctx = createInitialState(ASSET_DEFS.slice(0,1));
   ctx.state.cash = 123;
-  const ok = save(ctx.state, ctx.market, ctx.assets, 1);
+  ctx.riskTrack[ctx.assets[0].sym] = { peak: 100, lastTP: 1, lastRule: 'TP1' };
+  const ok = save(ctx.state, ctx.market, ctx.assets, ctx.riskTrack, SAVE_VERSION);
   expect(ok).toBe(true);
   ctx.state.cash = 0;
-  const loaded = load(ctx, 1);
+  ctx.riskTrack = {};
+  const loaded = load(ctx, SAVE_VERSION);
   expect(loaded).toBe(true);
   expect(ctx.state.cash).toBe(123);
+  expect(ctx.riskTrack[ctx.assets[0].sym].lastRule).toBe('TP1');
 });


### PR DESCRIPTION
## Summary
- Save and load risk rule tracking data alongside other state
- Bump save file schema to v2 and migrate older v1 saves
- Cover persistence with a new unit test and update changelog

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0c8cdeef0832aa0d9e5bc4c76d9e3