### PR TITLE
feat: add debug panel for last risk rule and event

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -29,6 +29,7 @@
           <button id="saveBtn" aria-label="Save game">Save</button>
           <button id="helpBtn" aria-label="Help">Help</button>
           <button id="contrastBtn" aria-label="Toggle high contrast mode" aria-pressed="false">Contrast</button>
+          <button id="debugBtn" aria-label="Toggle debug info" aria-pressed="false">Debug</button>
           <button id="resetBtn" class="bad" aria-label="Hard reset game">Hard Reset</button>
         </div>
       </div>
@@ -77,6 +78,7 @@
     </div>
 
     <div class="card" id="riskTools"></div>
+    <div class="card" id="debugPanel" style="display:none"></div>
   </section>
 </div>
 

--- a/src/js/core/cycle.js
+++ b/src/js/core/cycle.js
@@ -53,7 +53,7 @@ export function stepTick(ctx, cfg, rng, hooks){
     ev.timing = 'intraday'; ev.t = cfg.DAY_TICKS * 2;
     ctx.market.activeEvents.push(ev);
     hooks?.log?.(`${ev.scope==='global'?'GLOBAL':ev.sym}: ${ev.title} (intraday) — ${ev.blurb}`);
-    pushAssetNews(ctx.newsByAsset, ev, `Day ${ctx.day.idx} (intraday)`, ctx.state);
+    pushAssetNews(ctx.newsByAsset, ev, `Day ${ctx.day.idx} (intraday)`, ctx.state, ctx.lastEvent);
     ctx.day.midEventFired = true;
   }
 
@@ -166,12 +166,12 @@ export function enqueueAfterHours(ctx, cfg, rng, hooks){
     const ev = randomEvent(ctx, rng); ev.timing = 'afterhours';
     ctx.market.tomorrow.push(ev);
     hooks?.log?.(`${ev.scope==='global'?'GLOBAL':ev.sym} (after‑hours): ${ev.title} — ${ev.blurb}`);
-    pushAssetNews(ctx.newsByAsset, ev, `Day ${ctx.day.idx} (after‑hours)`, ctx.state);
+    pushAssetNews(ctx.newsByAsset, ev, `Day ${ctx.day.idx} (after‑hours)`, ctx.state, ctx.lastEvent);
   }
   if (Math.random() < cfg.AH_SUPPLY_EVENT_P){
     const sev = randomSupplyEvent(ctx.assets, rng); sev.timing = 'afterhours';
     ctx.market.tomorrow.push(sev);
     hooks?.log?.(`${sev.scope==='global'?'GLOBAL':sev.sym} (after‑hours): ${sev.title} — ${sev.blurb}`);
-    pushAssetNews(ctx.newsByAsset, sev, `Day ${ctx.day.idx} (after‑hours)`, ctx.state);
+    pushAssetNews(ctx.newsByAsset, sev, `Day ${ctx.day.idx} (after‑hours)`, ctx.state, ctx.lastEvent);
   }
 }

--- a/src/js/core/events.js
+++ b/src/js/core/events.js
@@ -71,18 +71,20 @@ export function randomSupplyEvent(assets, rng){
           severity:(Math.abs(frac)>0.05 ? "major":"minor"), blurb:`Supply ${up?"+":""}${Math.round(frac*100)}%.`};
 }
 
-export function pushAssetNews(newsByAsset, ev, whenLabel, state){
+export function pushAssetNews(newsByAsset, ev, whenLabel, state, lastEvent){
   if (ev.requires && state && !ev.requires.every(id => state.upgrades[id])) return;
   const targets = ev.scope === 'asset' ? [ev.sym] : null;
   if (targets) {
     newsByAsset[ev.sym] = newsByAsset[ev.sym] || [];
     newsByAsset[ev.sym].unshift({ when: whenLabel, ev, remaining: ev.days || 2 });
     if (newsByAsset[ev.sym].length > 50) newsByAsset[ev.sym].pop();
+    if (lastEvent) lastEvent[ev.sym] = ev;
   } else {
     // global → copy into each asset stream
     Object.keys(newsByAsset).forEach(sym => {
       newsByAsset[sym].unshift({ when: whenLabel, ev, remaining: ev.days || 2 });
       if (newsByAsset[sym].length > 50) newsByAsset[sym].pop();
+      if (lastEvent) lastEvent[sym] = ev;
     });
   }
 }

--- a/src/js/core/state.js
+++ b/src/js/core/state.js
@@ -45,7 +45,7 @@ export function createInitialState(assetDefs){
     upgrades: { insider:false, leverage:0, debt_rate:false, options:false, crypto:false },
     upgradePurchases: { insider:0, leverage:0, debt_rate:0, options:0, crypto:0 },
     cooldowns: { insider:0 },
-    ui: { lastLev: {} },
+    ui: { lastLev: {}, debug:false },
     marginPositions: [],
     optionPositions: [],
     insiderTip: null,
@@ -69,6 +69,6 @@ export function createInitialState(assetDefs){
   };
 
   // Misc runtime trackers
-  const ctx = { assets, state, market, day, newsByAsset, riskTrack: {}, gameOver:false };
+  const ctx = { assets, state, market, day, newsByAsset, riskTrack: {}, lastEvent:{}, gameOver:false };
   return ctx;
 }

--- a/src/js/ui/debug.js
+++ b/src/js/ui/debug.js
@@ -1,0 +1,15 @@
+export function renderDebug(ctx){
+  const panel = document.getElementById('debugPanel');
+  if (!panel) return;
+  if (!ctx.state.ui?.debug){
+    panel.style.display = 'none';
+    return;
+  }
+  panel.style.display = 'block';
+  const sym = ctx.selected;
+  const lastRule = ctx.riskTrack[sym]?.lastRule || '—';
+  const ev = ctx.lastEvent[sym];
+  const evTitle = ev ? ev.title : '—';
+  panel.innerHTML = `<div class="mini">Last Auto‑Risk: ${lastRule}</div>` +
+    `<div class="mini">Last Event: ${evTitle}</div>`;
+}

--- a/src/js/ui/init.js
+++ b/src/js/ui/init.js
@@ -10,6 +10,7 @@ import { renderUpgrades } from './upgrades.js';
 import { buy, sell } from '../core/trading.js';
 import { buyOption } from '../core/options.js';
 import { showHelp } from './modal.js';
+import { renderDebug } from './debug.js';
 
 export function initUI(ctx, handlers) {
   const { start, save, reset } = handlers;
@@ -126,6 +127,16 @@ export function initUI(ctx, handlers) {
     });
   }
 
+  const debugBtn = document.getElementById('debugBtn');
+  if (debugBtn) {
+    debugBtn.setAttribute('aria-pressed', ctx.state.ui.debug);
+    debugBtn.addEventListener('click', () => {
+      ctx.state.ui.debug = !ctx.state.ui.debug;
+      debugBtn.setAttribute('aria-pressed', ctx.state.ui.debug);
+      renderDebug(ctx);
+    });
+  }
+
   document.getElementById('startBtn').addEventListener('click', start);
   document.getElementById('saveBtn').addEventListener('click', save);
   document.getElementById('helpBtn').addEventListener('click', showHelp);
@@ -143,6 +154,7 @@ export function initUI(ctx, handlers) {
     renderUpgrades(ctx, toast);
     ctx.renderMarketTabs();
     ctx.renderRiskStats?.();
+    renderDebug(ctx);
   }
   ctx.renderAll = renderAll;
 

--- a/src/js/ui/upgrades.js
+++ b/src/js/ui/upgrades.js
@@ -102,7 +102,7 @@ export function renderUpgrades(ctx, toast){
         ctx.state.insiderTip = { sym, daysLeft: CFG.INSIDER_DAYS, mu, sigma, bias };
         ctx.state.cooldowns.insider = CFG.INSIDER_COOLDOWN_DAYS;
         ctx.state.upgrades.insider = true;
-        pushAssetNews(ctx.newsByAsset, { scope:'asset', sym, title: bias>0?'Bullish tip':'Bearish tip', type:'insider', mu, sigma, demand:0, days: CFG.INSIDER_DAYS, severity:'minor', blurb: bias>0?'Upward whispers.':'Downward whispers.' }, `Day ${ctx.day.idx} (tip)`, ctx.state);
+        pushAssetNews(ctx.newsByAsset, { scope:'asset', sym, title: bias>0?'Bullish tip':'Bearish tip', type:'insider', mu, sigma, demand:0, days: CFG.INSIDER_DAYS, severity:'minor', blurb: bias>0?'Upward whispers.':'Downward whispers.' }, `Day ${ctx.day.idx} (tip)`, ctx.state, ctx.lastEvent);
         msg = `Insider tip on ${sym} (${bias>0?'Bullish':'Bearish'}) purchased`;
       } else {
         ctx.state.cash -= cost;


### PR DESCRIPTION
## Summary
- add header Debug toggle that reveals a small debug panel
- track last market event per asset and expose recent auto-risk rule
- wire debug state and renderer to update during gameplay

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0ca82d298832a90c28e76d467e989