### PR TITLE
Format market cap stat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@
 - Insider tips now highlight the affected asset and apply visible drift for their duration.
 - Auto‑risk tools respect a one‑tick grace period after buying to prevent premature triggers.
 - Save data persists insider tips, risk settings, last trade ticks, and risk rule tracking for seamless reloads.
+- Market cap stat now rounds large values to whole dollars for clarity.

--- a/src/js/ui/chart.js
+++ b/src/js/ui/chart.js
@@ -1,4 +1,4 @@
-import { fmt } from '../util/format.js';
+import { fmt, fmtBig } from '../util/format.js';
 import { CFG } from '../config.js';
 
 export function initChart(ctx){
@@ -184,9 +184,11 @@ export function drawChart(ctx) {
   else if (demandVal < 1.1) demandCat = 'Medium';
   else if (demandVal < 1.3) demandCat = 'High';
   else demandCat = 'Extreme';
+  const capVal = last * a.supply;
+  const capStr = '$' + fmtBig(capVal, capVal >= 1_000_000 ? 0 : 2);
   const rows = [
     ['Supply', a.supply.toLocaleString()],
-    ['Market Cap', fmt(last * a.supply)],
+    ['Market Cap', capStr],
     ['Local Demand', demandCat],
     ['Fair Value', fmt(a.fair)],
     ['Tomorrow (μ ± σ)', `${((a.outlook?.mu || 0) * 100).toFixed(2)}% ± ${((a.outlook?.sigma || a.daySigma || 0) * 100).toFixed(2)}%`],


### PR DESCRIPTION
## Summary
- Round market cap stat to whole dollars for large values to avoid distracting decimals

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0dc116620832aa4e9d88cc2247531