### PR TITLE
Fix leverage Buy Max and refine summary modal

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -154,6 +154,7 @@ fieldset.rt-group legend{padding:0 4px}
 .modal .actions{display:flex;gap:8px;justify-content:flex-end;margin-top:10px}
 .modal table{width:100%;border-collapse:separate;border-spacing:0}
 .modal th,.modal td{padding:6px 8px;border-bottom:1px dashed rgba(255,255,255,.08);vertical-align:top}
+.modal th.r,.modal td.r{text-align:right}
 .badge{display:inline-block;padding:2px 6px;border:1px solid var(--border);border-radius:999px;font-size:11px;color:var(--muted)}
 .up{color:var(--good)} .down{color:var(--bad)}
 

--- a/src/js/ui/modal.js
+++ b/src/js/ui/modal.js
@@ -8,6 +8,7 @@ export function showSummary(summary, onNext){
   const { rows, meta } = summary;
   const dNetClass = meta.dNet >= 0 ? 'up' : 'down';
   const realizedClass = meta.realized >= 0 ? 'up' : 'down';
+  const fired = rows.filter(r => r.lastRule).map(r => `${r.sym} ${r.lastRule}`);
 
   const header = `
     <h3>Day ${meta.day} Summary</h3>
@@ -23,12 +24,12 @@ export function showSummary(summary, onNext){
     </div>
     ${meta.interest>0?`<div class="mini">Debt interest charged: ${fmt(meta.interest)}</div>`:''}`;
 
-  modalContent.innerHTML = header;
+  modalContent.innerHTML = header + (fired.length ? `<div class="mini">Auto‑Risk: ${fired.join(', ')}</div>` : '');
 
   const table = document.createElement('table');
   table.innerHTML = `<thead><tr>
-    <th>Asset</th><th>Start</th><th>End</th><th>Δ%</th>
-    <th>Pos (start)</th><th>Pos (end)</th><th>Unrealized Δ</th>
+    <th>Asset</th><th class="r">Start</th><th class="r">End</th><th class="r">Δ%</th>
+    <th class="r">Pos (start)</th><th class="r">Pos (end)</th><th class="r">Unrealized Δ</th>
   </tr></thead>`;
   const tbody = document.createElement('tbody');
   for (const r of rows){
@@ -36,19 +37,23 @@ export function showSummary(summary, onNext){
     const tdAsset = document.createElement('td');
     tdAsset.innerHTML = `<b>${r.sym}</b> <span class="mini">${r.name}</span>`;
     const tdStart = document.createElement('td');
+    tdStart.className = 'r';
     tdStart.textContent = fmt(r.sp);
     const tdEnd = document.createElement('td');
+    tdEnd.className = 'r';
     tdEnd.textContent = fmt(r.ep);
     const tdCh = document.createElement('td');
+    tdCh.className = 'r ' + (r.priceCh >= 0 ? 'up' : 'down');
     tdCh.textContent = `${(r.priceCh*100).toFixed(2)}%`;
-    tdCh.className = r.priceCh >= 0 ? 'up' : 'down';
     const tdPosStart = document.createElement('td');
+    tdPosStart.className = 'r';
     tdPosStart.textContent = `${r.startHold.toLocaleString()} • ${fmt(r.startVal)}`;
     const tdPosEnd = document.createElement('td');
+    tdPosEnd.className = 'r';
     tdPosEnd.textContent = `${r.endHold.toLocaleString()} • ${fmt(r.endVal)}`;
     const tdUnreal = document.createElement('td');
+    tdUnreal.className = 'r ' + (r.unreal >= 0 ? 'up' : 'down');
     tdUnreal.textContent = `${r.unreal>=0?'+':''}${fmt(r.unreal)}`;
-    tdUnreal.className = r.unreal >= 0 ? 'up' : 'down';
 
     tr.appendChild(tdAsset);
     tr.appendChild(tdStart);
@@ -64,19 +69,17 @@ export function showSummary(summary, onNext){
 
   const rtable = document.createElement('table');
   rtable.innerHTML = `<thead><tr>
-    <th>Asset</th><th>Basis</th><th>Peak</th><th>Ret%</th><th>DD%</th><th>Next TP</th><th>Last Rule</th>
+    <th>Asset</th><th class="r">Basis</th><th class="r">Peak</th><th class="r">Ret%</th><th class="r">DD%</th><th class="r">Next TP</th><th>Last Rule</th>
   </tr></thead>`;
   const rtbody = document.createElement('tbody');
   for (const r of rows){
     const tr = document.createElement('tr');
     const tdAsset = document.createElement('td'); tdAsset.textContent = r.sym;
-    const tdBasis = document.createElement('td'); tdBasis.textContent = fmt(r.basis);
-    const tdPeak = document.createElement('td'); tdPeak.textContent = fmt(r.peak);
-    const tdRet = document.createElement('td'); tdRet.textContent = `${(r.ret*100).toFixed(1)}%`;
-    tdRet.className = r.ret >= 0 ? 'up' : 'down';
-    const tdDD = document.createElement('td'); tdDD.textContent = `${(r.draw*100).toFixed(1)}%`;
-    tdDD.className = r.draw >= 0 ? 'up' : 'down';
-    const tdNext = document.createElement('td'); tdNext.textContent = r.nextTP!=null ? `${Math.round(r.nextTP*100)}%` : '—';
+    const tdBasis = document.createElement('td'); tdBasis.className='r'; tdBasis.textContent = fmt(r.basis);
+    const tdPeak = document.createElement('td'); tdPeak.className='r'; tdPeak.textContent = fmt(r.peak);
+    const tdRet = document.createElement('td'); tdRet.className='r ' + (r.ret >= 0 ? 'up' : 'down'); tdRet.textContent = `${(r.ret*100).toFixed(1)}%`;
+    const tdDD = document.createElement('td'); tdDD.className='r ' + (r.draw >= 0 ? 'up' : 'down'); tdDD.textContent = `${(r.draw*100).toFixed(1)}%`;
+    const tdNext = document.createElement('td'); tdNext.className='r'; tdNext.textContent = r.nextTP!=null ? `${Math.round(r.nextTP*100)}%` : '—';
     const tdLast = document.createElement('td'); tdLast.textContent = r.lastRule || '—';
     tr.append(tdAsset, tdBasis, tdPeak, tdRet, tdDD, tdNext, tdLast);
     rtbody.appendChild(tr);

--- a/src/js/ui/table.js
+++ b/src/js/ui/table.js
@@ -263,16 +263,16 @@ export function buildMarketTable({ table, assets, state, onSelect, onBuy, onSell
     });
     buyMaxBtn.addEventListener('click', () => {
       const price = a.price;
+      const lev = getLev();
       let qty = Math.floor((state.cash - state.minFee) / price);
       if (qty < 0) qty = 0;
       while (qty > 0) {
-        const fee = Math.max(state.minFee, qty * price * state.feeRate);
-        const lev = getLev();
-        const cost = qty * price * (lev > 1 ? 1 / lev : 1) + fee;
+        const exposure = qty * (lev > 1 ? lev : 1);
+        const fee = Math.max(state.minFee, exposure * price * state.feeRate);
+        const cost = qty * price + fee;
         if (cost <= state.cash) break;
         qty--;
       }
-      const lev = getLev();
       onBuy(a.sym, qty, lev);
     });
     sellBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Correct Buy Max calculation for leveraged trades to base fees on full exposure, preventing zero-quantity purchases
- Improve end-of-day summary modal with right-aligned figures and a note of any Auto-Risk triggers
- Add CSS utility to right-align modal table columns

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0dd5e41fc832a84c65c5bf5d838a9