### PR TITLE
feat: scaffold two-pane layout with tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,21 +7,21 @@
   <link rel="stylesheet" href="src/css/main.css" />
 </head>
 <body>
-<header class="hdr">
-  <div class="brand">🛰️ To‑The‑Moon <small id="version"></small></div>
-  <div class="stats">
-    <div class="pill"><span class="label">Day</span> <b id="dayNum">0</b> • <span class="kbd" id="dayTimer">—s</span></div>
-    <div class="pill"><span class="label">Cash</span> <b id="cash">$0.00</b></div>
-    <div class="pill"><span class="label">Debt</span> <b id="debt">$0.00</b></div>
-    <div class="pill"><span class="label">Assets</span> <b id="assets">$0.00</b></div>
-    <div class="pill"><span class="label">Net</span> <b id="net">$0.00</b></div>
-    <div class="pill"><span class="label">Risk</span> <b id="riskPct">0%</b></div>
-  </div>
-</header>
+<div id="app">
+  <header id="hud" class="hud panel">
+    <div class="brand">🛰️ To‑The‑Moon <small id="version"></small></div>
+    <div class="stats">
+      <div class="pill"><span class="label">Day</span> <b id="dayNum">0</b> • <span class="kbd" id="dayTimer">—s</span></div>
+      <div class="pill"><span class="label">Cash</span> <b id="cash">$0.00</b></div>
+      <div class="pill"><span class="label">Debt</span> <b id="debt">$0.00</b></div>
+      <div class="pill"><span class="label">Assets</span> <b id="assets">$0.00</b></div>
+      <div class="pill"><span class="label">Net</span> <b id="net">$0.00</b></div>
+      <div class="pill"><span class="label">Risk</span> <b id="riskPct">0%</b></div>
+    </div>
+  </header>
 
-<div class="grid">
-  <section class="market-col">
-    <div class="panel market-panel">
+  <main id="layout" class="layout">
+    <aside id="market" class="market panel" aria-label="Market">
       <div class="market-header row">
         <div class="mini">10‑second days • After‑hours news drives tomorrow</div>
         <div class="row">
@@ -34,62 +34,53 @@
         </div>
       </div>
       <table id="marketTable" aria-label="Market data table"></table>
-    </div>
-  </section>
+    </aside>
 
-  <section class="mid-col">
-    <div class="panel">
-      <div class="row" style="justify-content:space-between;">
-        <div class="row" style="align-items:center;">
-          <span>Chart: <b id="chartTitle"></b></span>
-          <button id="chartToggle" aria-label="Toggle chart type">Candles</button>
-          <div id="chartIntervals" class="row">
-            <button class="chip-btn" data-interval="hour" aria-pressed="true">1H</button>
-            <button class="chip-btn" data-interval="day" aria-pressed="false">1D</button>
-            <button class="chip-btn" data-interval="week" aria-pressed="false">1W</button>
-            <button class="chip-btn" data-interval="month" aria-pressed="false">1M</button>
+    <section id="details" class="details panel" aria-label="Details">
+      <nav class="tabs" role="tablist">
+        <button role="tab" aria-selected="true" data-tab="chart">Chart</button>
+        <button role="tab" aria-selected="false" data-tab="risk">Risk</button>
+        <button role="tab" aria-selected="false" data-tab="news">News</button>
+        <span class="spacer"></span>
+        <button class="primary trade" id="open-trade">Trade</button>
+      </nav>
+      <div id="panel-chart" role="tabpanel">
+        <div class="row" style="justify-content:space-between;">
+          <div class="row" style="align-items:center;">
+            <span>Chart: <b id="chartTitle"></b></span>
+            <button id="chartToggle" aria-label="Toggle chart type">Candles</button>
+            <div id="chartIntervals" class="row">
+              <button class="chip-btn" data-interval="hour" aria-pressed="true">1H</button>
+              <button class="chip-btn" data-interval="day" aria-pressed="false">1D</button>
+              <button class="chip-btn" data-interval="week" aria-pressed="false">1W</button>
+              <button class="chip-btn" data-interval="month" aria-pressed="false">1M</button>
+            </div>
+            <input type="range" id="chartZoomRange" min="1" max="100" value="1" aria-label="Chart zoom" />
           </div>
-          <input type="range" id="chartZoomRange" min="1" max="100" value="1" aria-label="Chart zoom" />
+          <div class="row">
+            <span class="tag">Prev close = dashed</span>
+            <span class="tag">Boundaries = day ends</span>
+          </div>
         </div>
-        <div class="row">
-          <span class="tag">Prev close = dashed</span>
-          <span class="tag">Boundaries = day ends</span>
+        <div class="chart-wrap"><canvas id="chart" width="820" height="300" role="img" aria-label="Asset price chart"></canvas><div id="chartTooltip" class="chart-tooltip" role="tooltip"></div></div>
+        <div class="statgrid" id="chartStats"></div>
+      </div>
+      <div id="panel-risk" role="tabpanel" hidden></div>
+      <div id="panel-news" role="tabpanel" hidden>
+        <div class="row" style="justify-content:space-between;">
+          <div>News & Events — <b id="newsSymbol"></b></div>
+          <div class="row" style="align-items:center;">
+            <div class="mini">Follow the selected asset</div>
+            <button id="majorOnly" class="chip-btn" aria-pressed="false" aria-label="Show major news only">Major</button>
+            <button id="newsCollapse" class="chip-btn" aria-label="Collapse news panel" aria-expanded="true">Collapse</button>
+          </div>
+        </div>
+        <div id="newsPanel">
+          <div id="newsScroll"><div id="newsTable"></div></div>
         </div>
       </div>
-      <div class="chart-wrap"><canvas id="chart" width="820" height="300" role="img" aria-label="Asset price chart"></canvas><div id="chartTooltip" class="chart-tooltip" role="tooltip"></div></div>
-      <div class="statgrid" id="chartStats"></div>
-    </div>
-
-    <div class="panel">
-      <div class="row" style="justify-content:space-between;">
-        <div>News & Events — <b id="newsSymbol"></b></div>
-        <div class="row" style="align-items:center;">
-          <div class="mini">Follow the selected asset</div>
-          <button id="majorOnly" class="chip-btn" aria-pressed="false" aria-label="Show major news only">Major</button>
-          <button id="newsCollapse" class="chip-btn" aria-label="Collapse news panel" aria-expanded="true">Collapse</button>
-        </div>
-      </div>
-      <div id="newsPanel">
-        <div id="newsScroll"><div id="newsTable"></div></div>
-      </div>
-    </div>
-  </section>
-
-  <section class="right-rail">
-    <div class="panel" id="portfolio"></div>
-    <div class="panel" id="upgrades"></div>
-    <div class="panel">
-      <div class="row" style="justify-content:space-between;">
-        <div>Asset Insight</div>
-        <div class="mini">Tomorrow (μ ± σ) • expected gap • recent news</div>
-      </div>
-      <div class="row mini" id="analystLine"></div>
-      <div class="asset-news" id="assetNews"></div>
-    </div>
-
-    <div class="panel" id="riskTools"></div>
-    <div class="panel" id="debugPanel" style="display:none"></div>
-  </section>
+    </section>
+  </main>
 </div>
 
 <!-- Toasts -->

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -22,7 +22,7 @@
 *{box-sizing:border-box}
 html,body{height:100%;margin:0;background:var(--bg);color:var(--text);
   font:clamp(14px,1.6vw,16px)/1.4 system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,"Apple Color Emoji","Segoe UI Emoji"}
-.hdr{display:flex;justify-content:space-between;align-items:center;padding:var(--space-2) var(--space-4);
+.hud{display:flex;justify-content:space-between;align-items:center;padding:var(--space-2) var(--space-4);
   background:linear-gradient(180deg,#0f1620,#0c1219);border-bottom:1px solid var(--border);position:sticky;top:0;z-index:5}
 .brand{font-weight:700}.brand small{color:var(--muted);margin-left:var(--space-2)}
 .stats{display:flex;gap:var(--space-2);flex-wrap:wrap;align-items:center}
@@ -30,6 +30,18 @@ html,body{height:100%;margin:0;background:var(--bg);color:var(--text);
 .kbd{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:var(--fs-xs)}
 .grid{display:grid;grid-template-columns:1fr 2fr 320px;grid-template-areas:"market mid right";gap:var(--space-4);padding:var(--space-4);max-width:1500px;margin:0}
 @media (max-width:1100px){.grid{grid-template-columns:1fr;grid-template-areas:"market" "mid" "right"}}
+
+.layout{
+  display:grid;
+  grid-template-columns:360px 1fr;
+  grid-template-rows:1fr;
+  gap:12px;
+  height:calc(100vh - 64px);
+}
+
+.market{overflow:auto;}
+.details{display:grid;grid-template-rows:auto 1fr;overflow:hidden;}
+.tabs{display:grid;grid-template-columns:auto auto auto 1fr auto;gap:8px;align-items:center;}
 .panel{
   background:var(--panel);
   border:1px solid var(--border);
@@ -48,7 +60,7 @@ html,body{height:100%;margin:0;background:var(--bg);color:var(--text);
 .label{color:var(--muted);opacity:.8}
 .mini{font-size:var(--fs-xs);color:var(--muted);opacity:.8}
 .tag{font-size:var(--fs-xs);padding:2px 6px;border:1px solid var(--border);border-radius:999px;color:var(--muted);opacity:.8}
-.tabs{margin-bottom:var(--space-2)}
+.market-tabs{margin-bottom:var(--space-2)}
 #marketTable{width:100%;border-collapse:separate;border-spacing:0;table-layout:fixed}
 table{width:100%;border-collapse:separate;border-spacing:0}
 thead th{position:sticky;top:0;background:var(--table);color:var(--muted);text-align:left;padding:var(--space-2);border-bottom:1px solid var(--border)}
@@ -150,7 +162,7 @@ canvas{width:100%;height:100%;background:#0a1017;border:1px solid var(--border);
 }
 
 @media (max-width:600px){
-  .hdr{flex-direction:column;align-items:flex-start}
+  .hud{flex-direction:column;align-items:flex-start}
   .stats{flex-direction:column;gap:var(--space-2);align-items:flex-start}
   .grid{grid-template-columns:1fr;padding:var(--space-2)}
   .right-rail{width:100%}

--- a/src/js/ui/init.js
+++ b/src/js/ui/init.js
@@ -1,12 +1,9 @@
 import { initToaster } from './toast.js';
 import { buildMarketTable, renderMarketTable } from './table.js';
 import { drawChart, initChart } from './chart.js';
-import { renderInsight } from './insight.js';
 import { renderAssetNewsTable, initNewsControls } from './newsAssets.js';
 import { renderHUD } from './hud.js';
 import { initRiskTools } from './risktools.js';
-import { renderPortfolio } from './portfolio.js';
-import { renderUpgrades } from './upgrades.js';
 import { buy, sell } from '../core/trading.js';
 import { showHelp } from './modal.js';
 import { renderDebug } from './debug.js';
@@ -41,9 +38,9 @@ export function initUI(ctx, handlers) {
 
   const tabs = document.createElement('div');
   tabs.id = 'marketTabs';
-  tabs.className = 'row tabs';
+  tabs.className = 'row market-tabs';
   tabs.setAttribute('role', 'tablist');
-  const panel = document.querySelector('.market-col .panel');
+  const panel = document.getElementById('market');
   panel.insertBefore(tabs, document.getElementById('marketTable'));
 
   function renderTabs() {
@@ -71,6 +68,22 @@ export function initUI(ctx, handlers) {
   renderTabs();
 
   initNewsControls(ctx);
+
+  const detailTabs = document.querySelectorAll('#details nav [role=tab]');
+  const panels = {
+    chart: document.getElementById('panel-chart'),
+    risk: document.getElementById('panel-risk'),
+    news: document.getElementById('panel-news')
+  };
+  detailTabs.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const tab = btn.dataset.tab;
+      detailTabs.forEach(b => b.setAttribute('aria-selected', b === btn));
+      Object.entries(panels).forEach(([id, el]) => {
+        el.hidden = id !== tab;
+      });
+    });
+  });
 
   ctx.chartMode = 'line';
   ctx.chartInterval = 'hour';
@@ -136,16 +149,13 @@ export function initUI(ctx, handlers) {
   document.getElementById('helpBtn').addEventListener('click', showHelp);
   document.getElementById('resetBtn').addEventListener('click', reset);
 
-  initRiskTools(document.getElementById('riskTools'), ctx, toast);
+  initRiskTools(document.getElementById('panel-risk'), ctx, toast);
 
   function renderAll() {
     renderHUD(ctx);
     renderMarketTable(ctx);
     drawChart(ctx);
-    renderInsight(ctx);
     renderAssetNewsTable(ctx);
-    renderPortfolio(ctx);
-    renderUpgrades(ctx, toast);
     ctx.renderMarketTabs();
     ctx.renderRiskStats?.();
     renderDebug(ctx);


### PR DESCRIPTION
## Summary
- Replace core app markup with two-pane layout and header scaffold
- Implement tabbed details area housing chart, risk tools, and news
- Introduce grid-based layout styles for new panes and tabs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0e96136cc832ab3ec18ce2444fb18