### PR TITLE
Restore start controls and live ticker updates

### DIFF
--- a/src/js/ui/init.js
+++ b/src/js/ui/init.js
@@ -10,7 +10,17 @@ export function initUI({ start, save, reset }) {
   app.innerHTML = `
     <header id="hud" class="hud panel"></header>
     <main id="layout" class="layout">
-      <aside id="col-left" class="panel col-left" aria-label="Market"></aside>
+      <aside id="col-left" class="panel col-left" aria-label="Market">
+        <div class="market-header row">
+          <div class="mini">10‑second days • After‑hours news drives tomorrow</div>
+          <div class="row">
+            <button id="startBtn" class="accent" aria-label="Start day">▶ Start Day</button>
+            <button id="saveBtn" aria-label="Save game">Save</button>
+            <button id="resetBtn" class="bad" aria-label="Hard reset game">Hard Reset</button>
+          </div>
+        </div>
+        <div id="market-root"></div>
+      </aside>
       <section id="col-center" class="panel col-center" aria-label="Chart and details">
         <div id="chart-root" class="chart-root"></div>
         <div id="details-root" class="details-root" aria-live="polite"></div>
@@ -31,7 +41,7 @@ export function initUI({ start, save, reset }) {
     renderNews(document.getElementById('news-root'), { filter: sym });
   };
 
-  renderMarket(document.getElementById('col-left'), state, { onSelect });
+  const market = renderMarket(document.getElementById('market-root'), state, { onSelect });
 
   const first = state.assets[0]?.sym;
   if (first) {
@@ -49,6 +59,7 @@ export function initUI({ start, save, reset }) {
   function renderAll() {
     renderHUD(state);
     renderPortfolio(document.getElementById('portfolio-root'), state);
+    market.update();
   }
 
   return { renderAll, toast: () => {} };

--- a/src/js/ui/table.js
+++ b/src/js/ui/table.js
@@ -18,6 +18,22 @@ export function renderMarket(root, ctx, { onSelect } = {}) {
 
   ctx.assets.forEach((a, i) => list.appendChild(makeRow(a, i === 0)));
 
+  function update() {
+    ctx.assets.forEach(a => {
+      const row = list.querySelector(`.asset-row[data-sym="${a.sym}"]`);
+      if (!row) return;
+      row.querySelector('.price').textContent = fmt(a.price);
+      const start = ctx.day.startPrices?.[a.sym] ?? a.price;
+      const pct = (a.price / start - 1) * 100;
+      const chgEl = row.querySelector('.chg');
+      chgEl.textContent = `${pct >= 0 ? '+' : ''}${pct.toFixed(2)}%`;
+      chgEl.classList.toggle('up', pct >= 0);
+      chgEl.classList.toggle('down', pct < 0);
+      const tk = row.querySelector(`#tk-${a.sym}`);
+      if (tk) tk.textContent = fmt(a.price);
+    });
+  }
+
   function makeRow(asset, selected) {
     const li = document.createElement('li');
     li.className = `asset-row${selected ? ' selected' : ''}`;
@@ -88,4 +104,6 @@ export function renderMarket(root, ctx, { onSelect } = {}) {
       li.focus();
     }
   }
+
+  return { update };
 }


### PR DESCRIPTION
## Summary
- Render market controls including Start Day, Save, and Reset in the UI
- Add real-time price and day change updates for each asset's ticker

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a109e3d788832a9afdedfc005aab68