### PR TITLE
Guard optional upgrade hooks and clean buy flow

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -140,8 +140,6 @@
       if (state.tick % 16 === 0) save();
     }
     
-    Upgrades.applyBiasOnTick(asset);
-
     function stepAll(steps = 1, varianceBoost = 1.0) {
       for (let s = 0; s < steps; s++) {
         for (const a of state.assets) {
@@ -159,6 +157,10 @@
 
           a.history.push(a.price);
           if (a.history.length > 240) a.history.shift();
+
+          if (window.Upgrades?.applyBiasOnTick) {
+            window.Upgrades.applyBiasOnTick(a);
+          }
         }
       }
     }
@@ -279,46 +281,47 @@
 
     // ----- Trading -----
     function doBuy(id, qty) {
-     const a = findAsset(id);
-     const cost = a.price * qty;
-   
-     const hasMargin = !!(window.ttm && window.ttm.margin);
-     const pv = portfolioValue();
+      const a = findAsset(id);
+      const cost = a.price * qty;
 
-     const cost = price * qty;
-     const borrowed = Upgrades.maybeBorrow({ cost, cash: state.cash, equity: state.cash + portfolioValue() });
-     state.cash += borrowed;
-     // proceed with your existing buy logic
+      const hasMargin = !!(window.ttm && window.ttm.margin);
+      const pv = portfolioValue();
 
-   
-     if (hasMargin) {
-       if (window.ttm.margin.isUnderMaintenance(state, pv)) {
-         bumpNews("Buy blocked: maintenance margin breached.");
-         return;
-       }
-       const ok = window.ttm.margin.buyWithMargin(state, cost, pv);
-       if (!ok) {
-         bumpNews(`Insufficient buying power for ${qty} ${id}.`);
-         return;
-       }
-     } else {
-       if (cost > state.cash + 1e-9) {
-         bumpNews(`Not enough cash to buy ${qty} ${id}.`);
-         return;
-       }
-       state.cash -= cost;
-     }
-   
-     const p = state.positions[id] || { qty: 0, avgCost: 0 };
-     const newQty = p.qty + qty;
-     const newCostBasis = (p.avgCost * p.qty + cost) / newQty;
-     state.positions[id] = { qty: newQty, avgCost: newCostBasis };
-   
-     save();
-     safeRenderAll();
-     selectAsset(id);
-     bumpNews(`Bought ${qty} ${id} @ ${formatPrice(a.price)}.`);
-   }
+      const borrowed = window.Upgrades?.maybeBorrow?.({
+        cost,
+        cash: state.cash,
+        equity: state.cash + pv
+      }) ?? 0;
+      state.cash += borrowed;
+
+      if (hasMargin) {
+        if (window.ttm.margin.isUnderMaintenance(state, pv)) {
+          bumpNews("Buy blocked: maintenance margin breached.");
+          return;
+        }
+        const ok = window.ttm.margin.buyWithMargin(state, cost, pv);
+        if (!ok) {
+          bumpNews(`Insufficient buying power for ${qty} ${id}.`);
+          return;
+        }
+      } else {
+        if (cost > state.cash + 1e-9) {
+          bumpNews(`Not enough cash to buy ${qty} ${id}.`);
+          return;
+        }
+        state.cash -= cost;
+      }
+
+      const p = state.positions[id] || { qty: 0, avgCost: 0 };
+      const newQty = p.qty + qty;
+      const newCostBasis = (p.avgCost * p.qty + cost) / newQty;
+      state.positions[id] = { qty: newQty, avgCost: newCostBasis };
+
+      save();
+      safeRenderAll();
+      selectAsset(id);
+      bumpNews(`Bought ${qty} ${id} @ ${formatPrice(a.price)}.`);
+    }
 
 
     function doSell(id, qty) {
@@ -701,8 +704,18 @@
         state.day += 1;
         startNewDay();
         save();
-        safeRenderAll();
-        Upgrades.accrueDailyInterest({ getCash:()=>state.cash, setCash:v=>{ state.cash=v; renderCash(v); } });
+        const accrueInterest = window.Upgrades?.accrueDailyInterest;
+        if (accrueInterest) {
+          accrueInterest({
+            getCash: () => state.cash,
+            setCash: (v) => {
+              state.cash = v;
+              safeRenderAll();
+            }
+          });
+        } else {
+          safeRenderAll();
+        }
       });
     if (elReset)
       elReset.addEventListener("click", () => {


### PR DESCRIPTION
## Summary
- guard optional upgrade hooks by wiring applyBiasOnTick inside the asset stepping loop
- streamline doBuy cost handling and only call optional borrow helpers when available
- replace the broken renderCash reference in the day-end interest callback with a safe render

## Testing
- Manual Playwright exercise of buy, sell, and End Day actions (Console errors captured: [])

------
https://chatgpt.com/codex/tasks/task_e_68caccfe03b8832a859bf658f770489c