### PR TITLE
Expose runtime handle for upgrades integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,28 +122,45 @@
   <script type="module" src="./js/core/insider.js"></script>
   <script type="module" src="./js/ui/upgrades.js"></script>
   <script type="module" src="./js/ui/insiderBanner.js"></script>
+  <script>window.__TTM_NO_AUTO__ = true;</script>
   <script type="module" src="./js/featurePack.js"></script>
   <script src="js/upgrades.js"></script>
 
-
   <script type="module">
     import { init } from "./js/featurePack.js";
-    // Example adapters; replace with your actual functions if available
-    const getPortfolioValue = () => window.computePortfolioValue ? window.computePortfolioValue() : 0;
-    const getAssetIds = () => (window.market?.assets || window.assets || []).map(a => a.id || a.symbol || a.ticker);
-    const onTick = (cb) => window.gameLoop?.onTick ? window.gameLoop.onTick(cb) : null; // optional
-  
-    init({ state: window.state, getPortfolioValue, getAssetIds, onTick });
-  </script>
 
-  <script>
-  // Example mappings — adjust to your actual state + UI
-  Upgrades.configure({
-    getCash: () => state.cash,
-    setCash: v => { state.cash = v; renderCash(v); },
-    getEquity: () => state.cash + portfolioValue(),          // your function to compute holdings value
-    listAssetKeys: () => assets.map(a => a.symbol || a.key)   // optional
-  });
+    let started = false;
+    const tryStart = (game) => {
+      if (started) return true;
+      if (!game || !game.state) return false;
+
+      const getPortfolioValue =
+        typeof game.portfolioValue === "function"
+          ? () => game.portfolioValue()
+          : () => 0;
+
+      const getAssetIds = () =>
+        Array.isArray(game.state?.assets) ? game.state.assets.map((asset) => asset.id) : [];
+
+      init({
+        state: game.state,
+        getPortfolioValue,
+        getAssetIds
+      });
+
+      started = true;
+      return true;
+    };
+
+    if (!tryStart(window.ttmGame)) {
+      window.addEventListener(
+        "ttm:gameReady",
+        (event) => {
+          tryStart(event.detail || window.ttmGame);
+        },
+        { once: true }
+      );
+    }
   </script>
 
 </body>


### PR DESCRIPTION
## Summary
- expose a stable `window.ttmGame` handle with state accessors and emit a readiness event for other bundles
- move and guard the `Upgrades.configure` wiring inside the main bootstrap so it only runs when the overlay is available
- update the HTML bootstrap to wait for the new game handle, disable auto-init, and drop the stale inline upgrade configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cacd4ad710832aae53d577ba8e111f