### PR TITLE
Refactor feature pack globals and event channel

### DIFF
--- a/js/featurePack.js
+++ b/js/featurePack.js
@@ -1,11 +1,15 @@
 // Bootstraps Margin + Insider + Shop + Persistence, and exposes globals.
 
-import { ensureUpgradeState } from "./core/upgrades.js";
-import { ensureMarginState, accrueDailyInterest } from "./core/margin.js";
-import { ensureInsiderState, maybeScheduleTip, clearIfExpired, applyInsiderBoost } from "./core/insider.js";
+import * as upgrades from "./core/upgrades.js";
+import * as margin from "./core/margin.js";
+import * as insider from "./core/insider.js";
 import { renderUpgradeShop } from "./ui/upgrades.js";
 import { updateInsiderBanner } from "./ui/insiderBanner.js";
 import { renderHudPatch } from "./ui/hudPatch.js";
+
+const { ensureUpgradeState } = upgrades;
+const { ensureMarginState, accrueDailyInterest } = margin;
+const { ensureInsiderState, maybeScheduleTip, clearIfExpired } = insider;
 
 // --- persistence (localStorage, our slices only) ---
 const LS_KEY = "ttm.upgrades.v1";
@@ -63,12 +67,10 @@ function tickOnce(state, getPV, getIds) {
 function exposeGlobals(api) {
   window.ttm = Object.freeze({
     ...api,
-    // Re-export frequently used helpers under a stable namespace
-    margin: await import("./core/margin.js"),
-    insider: await import("./core/insider.js"),
-    upgrades: await import("./core/upgrades.js"),
-    // Quick hook for price boost (for price model integration)
-    applyInsiderBoost: (state, assetId, basePrice) => applyInsiderBoost(state, assetId, basePrice),
+    margin: Object.freeze({ ...margin }),
+    insider: Object.freeze({ ...insider }),
+    upgrades: Object.freeze({ ...upgrades }),
+    applyInsiderBoost: insider.applyInsiderBoost,
   });
 }
 

--- a/js/ui/upgrades.js
+++ b/js/ui/upgrades.js
@@ -33,20 +33,8 @@ export function renderUpgradeShop(state) {
     const id = btn.getAttribute("data-id");
     if (purchaseUpgrade(state, id)) {
       renderUpgradeShop(state);
-      window.dispatchEvent(new CustomEvent("game:stateChanged"));
+      window.dispatchEvent(new CustomEvent("ttm:stateChanged"));
     }
   };
 }
 
-/* Upgrade pack styles. */
-#panel-upgrades { padding: 8px; }
-.upgrade-card { border: 1px solid #222; padding: 8px; margin: 6px 0; border-radius: 6px; }
-.upgrade-title { font-weight: 600; }
-.upgrade-desc { font-size: 0.9rem; opacity: 0.8; margin: 4px 0 8px; }
-.upgrade-cta { display: flex; justify-content: space-between; align-items: center; }
-#insider-banner { position: sticky; top: 0; padding: 6px 8px; border-bottom: 1px solid #333; background: #111; }
-#insider-banner.hidden { display: none; }
-
-#ttm-hud { position: fixed; right: 8px; bottom: 8px; z-index: 50; }
-#ttm-hud .ttm-hud { background: rgba(0,0,0,0.6); padding: 8px 10px; border: 1px solid #222; border-radius: 6px; font-size: 12px; line-height: 1.3; }
-#ttm-hud .ttm-hud div { white-space: nowrap; }


### PR DESCRIPTION
## Summary
- build the feature pack API using existing module imports and expose applyInsiderBoost directly
- align the upgrade shop event channel and remove stray CSS from the module so it parses cleanly in the browser

## Testing
- python - <<'PY' ... (the command)

------
https://chatgpt.com/codex/tasks/task_e_68cacd518c04832a9df1d939284c1470