### PR TITLE
Remove inline upgrade styles from module

### DIFF
--- a/js/ui/upgrades.js
+++ b/js/ui/upgrades.js
@@ -38,15 +38,3 @@ export function renderUpgradeShop(state) {
   };
 }
 
-/* Upgrade pack styles. */
-#panel-upgrades { padding: 8px; }
-.upgrade-card { border: 1px solid #222; padding: 8px; margin: 6px 0; border-radius: 6px; }
-.upgrade-title { font-weight: 600; }
-.upgrade-desc { font-size: 0.9rem; opacity: 0.8; margin: 4px 0 8px; }
-.upgrade-cta { display: flex; justify-content: space-between; align-items: center; }
-#insider-banner { position: sticky; top: 0; padding: 6px 8px; border-bottom: 1px solid #333; background: #111; }
-#insider-banner.hidden { display: none; }
-
-#ttm-hud { position: fixed; right: 8px; bottom: 8px; z-index: 50; }
-#ttm-hud .ttm-hud { background: rgba(0,0,0,0.6); padding: 8px 10px; border: 1px solid #222; border-radius: 6px; font-size: 12px; line-height: 1.3; }
-#ttm-hud .ttm-hud div { white-space: nowrap; }


### PR DESCRIPTION
## Summary
- remove the inline CSS block from the `js/ui/upgrades.js` module so it only exports JavaScript
- rely on the existing `css/upgrades.css` stylesheet that is already linked from `index.html`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cacd534cec832a9a40ee2f29acf0d3