### PR TITLE
Refactor game loop into reusable engine

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@
     <p>Prototype v0.1. Prices are simulated. If you lose money here, that’s on your decision-making, not the physics engine.</p>
   </footer>
 
-  <script src="js/main.js"></script>
+  <script type="module" src="./js/main.js"></script>
   <script type="module" src="./js/core/upgrades.js"></script>
   <script type="module" src="./js/core/margin.js"></script>
   <script type="module" src="./js/core/insider.js"></script>
@@ -132,18 +132,27 @@
     let started = false;
     const tryStart = (game) => {
       if (started) return true;
-      if (!game || !game.state) return false;
+      if (!game || typeof game.getState !== "function") return false;
 
-      const getPortfolioValue =
-        typeof game.portfolioValue === "function"
-          ? () => game.portfolioValue()
-          : () => 0;
+      const getPortfolioValue = (state) => {
+        if (typeof game.portfolioValue === "function") {
+          return game.portfolioValue(state);
+        }
+        const snapshot = state ?? game.getState();
+        if (!snapshot || !Array.isArray(snapshot.assets)) return 0;
+        return snapshot.assets.reduce((sum, asset) => {
+          const pos = snapshot.positions?.[asset.id];
+          return sum + (pos ? pos.qty * asset.price : 0);
+        }, 0);
+      };
 
-      const getAssetIds = () =>
-        Array.isArray(game.state?.assets) ? game.state.assets.map((asset) => asset.id) : [];
+      const getAssetIds = (state) => {
+        const snapshot = state ?? game.getState();
+        if (!snapshot || !Array.isArray(snapshot.assets)) return [];
+        return snapshot.assets.map((asset) => asset.id);
+      };
 
-      init({
-        state: game.state,
+      init(game, {
         getPortfolioValue,
         getAssetIds
       });

--- a/js/core/gameEngine.js
+++ b/js/core/gameEngine.js
@@ -1,0 +1,292 @@
+const DEFAULT_SAVE_KEY = "ttm_v0_save";
+const DEFAULT_TICK_INTERVAL = 600;
+const DEFAULT_AUTOSAVE_TICKS = 16;
+
+export const ASSET_DEFS = [
+  { id: "MOON", name: "Moon Mineral Co.", start: 50, volatility: 0.02 },
+  { id: "STONK", name: "Stonk Industries", start: 35, volatility: 0.03 },
+  { id: "DOGE", name: "Dogecoin", start: 0.08, volatility: 0.06 },
+  { id: "TSLA", name: "Teslor Motors", start: 240, volatility: 0.018 },
+  { id: "BTC", name: "Bitcorn", start: 65000, volatility: 0.03 },
+  { id: "ETH", name: "Etheer", start: 3500, volatility: 0.035 }
+];
+
+function mkAssetRuntime(def) {
+  return {
+    id: def.id,
+    name: def.name,
+    volatility: def.volatility,
+    price: def.start,
+    prev: def.start,
+    changePct: 0,
+    history: Array.from({ length: 60 }, (_, i) => def.start * (1 + (i - 59) * 0.0005))
+  };
+}
+
+export function createInitialState() {
+  return {
+    day: 1,
+    cash: 10000,
+    realized: 0,
+    assets: ASSET_DEFS.map(mkAssetRuntime),
+    positions: {},
+    running: false,
+    selected: "MOON",
+    tick: 0,
+    events: [],
+    feed: [],
+    nextEventId: 1
+  };
+}
+
+function normalizeAsset(asset = {}) {
+  const def = ASSET_DEFS.find((item) => item.id === asset.id);
+  const base = def ? mkAssetRuntime(def) : mkAssetRuntime({
+    id: asset.id || "ASSET",
+    name: asset.name || (def ? def.name : "Unknown"),
+    volatility: Number.isFinite(asset.volatility) ? asset.volatility : 0.02,
+    start: Number.isFinite(asset.price) ? asset.price : 1
+  });
+
+  const price = Number.isFinite(asset.price) ? asset.price : base.price;
+  const prev = Number.isFinite(asset.prev) ? asset.prev : price;
+  const history = Array.isArray(asset.history) && asset.history.length
+    ? asset.history.slice(-240)
+    : base.history;
+
+  return {
+    id: base.id,
+    name: base.name,
+    volatility: base.volatility,
+    price,
+    prev,
+    changePct: Number.isFinite(asset.changePct) ? asset.changePct : 0,
+    history
+  };
+}
+
+function normalizeState(raw) {
+  if (!raw || typeof raw !== "object") return createInitialState();
+  const base = createInitialState();
+
+  const state = {
+    day: Number.isFinite(raw.day) ? raw.day : base.day,
+    cash: Number.isFinite(raw.cash) ? raw.cash : base.cash,
+    realized: Number.isFinite(raw.realized) ? raw.realized : base.realized,
+    assets: Array.isArray(raw.assets) && raw.assets.length
+      ? raw.assets.map(normalizeAsset)
+      : base.assets,
+    positions: raw.positions && typeof raw.positions === "object" ? { ...raw.positions } : {},
+    running: false,
+    selected: typeof raw.selected === "string" ? raw.selected : base.selected,
+    tick: Number.isFinite(raw.tick) ? raw.tick : base.tick,
+    events: Array.isArray(raw.events) ? raw.events.map((event) => ({ ...event })) : [],
+    feed: Array.isArray(raw.feed) ? raw.feed.slice(-60).map((entry) => ({ ...entry })) : [],
+    nextEventId: Number.isFinite(raw.nextEventId) ? raw.nextEventId : base.nextEventId
+  };
+
+  // Ensure feed entries always have defaults.
+  state.feed = state.feed.map((entry) => ({
+    time: typeof entry.time === "string" ? entry.time : "",
+    text: typeof entry.text === "string" ? entry.text : "",
+    kind: typeof entry.kind === "string" ? entry.kind : "neutral",
+    targetId: entry.targetId ?? null,
+    effect: entry.effect ?? {},
+    expiresAtTick: entry.expiresAtTick ?? null,
+    expiresOnDay: entry.expiresOnDay ?? null
+  }));
+
+  // Guarantee each asset history entry is numeric.
+  state.assets = state.assets.map((asset) => ({
+    ...asset,
+    history: asset.history.map((value) => (Number.isFinite(value) ? value : asset.price))
+  }));
+
+  return state;
+}
+
+export function saveState(state, { storageKey = DEFAULT_SAVE_KEY } = {}) {
+  try {
+    localStorage.setItem(storageKey, JSON.stringify(state));
+  } catch (error) {
+    console.warn("ttm:saveState failed", error);
+  }
+}
+
+export function loadState({ storageKey = DEFAULT_SAVE_KEY } = {}) {
+  try {
+    const raw = localStorage.getItem(storageKey);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    return normalizeState(parsed);
+  } catch (error) {
+    console.warn("ttm:loadState failed", error);
+    return null;
+  }
+}
+
+export function createGameEngine({
+  state: providedState,
+  storageKey = DEFAULT_SAVE_KEY,
+  tickInterval = DEFAULT_TICK_INTERVAL,
+  autoSaveTicks = DEFAULT_AUTOSAVE_TICKS
+} = {}) {
+  let currentState = normalizeState(providedState ?? loadState({ storageKey }) ?? createInitialState());
+  currentState.running = false;
+
+  const tickHandlers = new Set();
+  const dayHandlers = new Set();
+  const renderHandlers = new Set();
+  const stateHandlers = new Set();
+
+  let timer = null;
+
+  const context = {
+    get state() {
+      return currentState;
+    },
+    requestSave,
+    requestRender: renderNow,
+    storageKey
+  };
+
+  function safeCall(fn, ...args) {
+    try {
+      fn(...args);
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  function notifyState() {
+    stateHandlers.forEach((handler) => safeCall(handler, currentState, context));
+  }
+
+  function renderNow() {
+    renderHandlers.forEach((handler) => safeCall(handler, currentState, context));
+  }
+
+  function requestSave() {
+    saveState(currentState, { storageKey });
+  }
+
+  function tickOnce() {
+    currentState.tick = (currentState.tick ?? 0) + 1;
+    tickHandlers.forEach((handler) => safeCall(handler, currentState, context));
+    if (autoSaveTicks && currentState.tick % autoSaveTicks === 0) {
+      requestSave();
+    }
+    notifyState();
+    renderNow();
+  }
+
+  function start() {
+    if (timer) clearInterval(timer);
+    currentState.running = true;
+    timer = setInterval(tickOnce, tickInterval);
+    notifyState();
+  }
+
+  function pause() {
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+    currentState.running = false;
+    notifyState();
+  }
+
+  function endDay(payload = {}) {
+    const dayContext = { ...context, ...payload };
+    dayHandlers.forEach((handler) => safeCall(handler, currentState, dayContext));
+    requestSave();
+    notifyState();
+    renderNow();
+  }
+
+  function onTick(handler) {
+    if (typeof handler === "function") tickHandlers.add(handler);
+    return () => tickHandlers.delete(handler);
+  }
+
+  function onDayEnd(handler) {
+    if (typeof handler === "function") dayHandlers.add(handler);
+    return () => dayHandlers.delete(handler);
+  }
+
+  function onRender(handler) {
+    if (typeof handler === "function") renderHandlers.add(handler);
+    return () => renderHandlers.delete(handler);
+  }
+
+  function onStateChange(handler) {
+    if (typeof handler === "function") stateHandlers.add(handler);
+    return () => stateHandlers.delete(handler);
+  }
+
+  function update(mutator, { save = true, render = true } = {}) {
+    if (typeof mutator !== "function") return;
+    try {
+      const next = mutator(currentState);
+      if (next && next !== currentState) {
+        currentState = normalizeState(next);
+      }
+    } catch (error) {
+      console.error(error);
+    }
+    if (save) requestSave();
+    notifyState();
+    if (render) renderNow();
+  }
+
+  function setState(nextState, { save = true, render = true } = {}) {
+    currentState = normalizeState(nextState);
+    if (save) requestSave();
+    notifyState();
+    if (render) renderNow();
+  }
+
+  function reset(newState = createInitialState()) {
+    pause();
+    setState(newState, { save: true, render: true });
+  }
+
+  function clearSave() {
+    try {
+      localStorage.removeItem(storageKey);
+    } catch (error) {
+      console.warn("ttm:clearSave failed", error);
+    }
+  }
+
+  const engine = {
+    getState: () => currentState,
+    start,
+    pause,
+    tickOnce,
+    endDay,
+    onTick,
+    onDayEnd,
+    onRender,
+    onStateChange,
+    update,
+    setState,
+    reset,
+    render: renderNow,
+    requestSave,
+    clearSave,
+    isRunning: () => timer != null,
+    get storageKey() {
+      return storageKey;
+    },
+    tickInterval,
+    autoSaveTicks
+  };
+
+  context.engine = engine;
+  notifyState();
+
+  return engine;
+}
+
+export { DEFAULT_SAVE_KEY };

--- a/js/core/upgrades.js
+++ b/js/core/upgrades.js
@@ -49,3 +49,27 @@ export function purchaseUpgrade(state, id) {
   state.upgrades.cashSpent += def.price;
   return true;
 }
+
+/**
+ * Ensure upgrade state exists within the engine and surface the helper API
+ * that feature packs expect. Does not add any automatic behaviour beyond
+ * hydrating the state slice.
+ */
+export function registerUpgrades(engine) {
+  if (!engine || typeof engine.update !== "function") {
+    throw new Error("registerUpgrades requires a game engine instance");
+  }
+
+  engine.update((state) => {
+    ensureUpgradeState(state);
+  }, { save: false, render: false });
+
+  return {
+    ensureUpgradeState,
+    hasUpgrade,
+    canAfford,
+    purchaseUpgrade,
+    UPGRADE_IDS,
+    UPGRADE_DEF
+  };
+}

--- a/js/featurePack.js
+++ b/js/featurePack.js
@@ -1,128 +1,84 @@
-// Bootstraps Margin + Insider + Shop + Persistence, and exposes globals.
+// Feature pack bootstrap: wires core systems to the shared game engine.
 
-import * as upgrades from "./core/upgrades.js";
-import * as margin from "./core/margin.js";
-import * as insider from "./core/insider.js";
+import { registerUpgrades } from "./core/upgrades.js";
+import { registerMargin } from "./core/margin.js";
+import { registerInsider } from "./core/insider.js";
 import { renderUpgradeShop } from "./ui/upgrades.js";
 import { updateInsiderBanner } from "./ui/insiderBanner.js";
 import { renderHudPatch } from "./ui/hudPatch.js";
 
-const { ensureUpgradeState } = upgrades;
-const { ensureMarginState, accrueDailyInterest } = margin;
-const { ensureInsiderState, maybeScheduleTip, clearIfExpired } = insider;
-
-// --- persistence (localStorage, our slices only) ---
-const LS_KEY = "ttm.upgrades.v1";
-function loadSlices() {
-  try { return JSON.parse(localStorage.getItem(LS_KEY) || "{}"); } catch { return {}; }
-}
-function saveSlices(state) {
-  const snapshot = {
-    upgrades: state.upgrades || null,
-    margin: state.margin || null,
-    insider: state.insider || null,
-  };
-  try { localStorage.setItem(LS_KEY, JSON.stringify(snapshot)); } catch {}
-}
-
-// --- integration helpers ---
-function defaultGetPortfolioValue() {
-  // Try common globals; fall back to 0.
-  const g = window.game || window.Game || window;
-  const assets = g.assets || g.market?.assets || [];
-  if (!assets || !assets.length) return 0;
-  // If positions exist elsewhere, this might diverge. This is only a fallback.
-  // Prefer passing getPortfolioValue in init().
-  return assets.reduce((s, a) => s + (a.price || 0) * (a.shares || 0), 0);
-}
-function defaultGetAssetIds() {
-  const g = window.game || window.Game || window;
-  const assets = g.assets || g.market?.assets || [];
-  return Array.isArray(assets) ? assets.map(a => a.id || a.symbol || a.ticker || "ASSET") : [];
-}
-
-function tickOnce(state, getPV, getIds) {
-  // Interest: accrue once per 60s of real time as a simple stand-in for "daily".
-  const now = Date.now();
-  if (!state.__ttmInterestAt) state.__ttmInterestAt = now + 60_000;
-  if (now >= state.__ttmInterestAt) {
-    accrueDailyInterest(state, 1);
-    state.__ttmInterestAt = now + 60_000;
+function defaultGetPortfolioValue(engine) {
+  if (typeof engine?.portfolioValue === "function") {
+    return engine.portfolioValue();
   }
-
-  // Insider scheduler + expiry
-  maybeScheduleTip(state, now, getIds());
-  clearIfExpired(state, now);
-
-  // HUD + banner
-  const pv = getPV();
-  renderHudPatch(state, pv);
-  updateInsiderBanner(state);
-
-  // Persist our slices
-  saveSlices(state);
+  const state = engine?.getState?.();
+  if (!state || !Array.isArray(state.assets)) return 0;
+  return state.assets.reduce((sum, asset) => {
+    const position = state.positions?.[asset.id];
+    return sum + (position ? position.qty * asset.price : 0);
+  }, 0);
 }
 
-// Public API
-function exposeGlobals(api) {
+function defaultGetAssetIds(engine, state) {
+  const snapshot = state ?? engine?.getState?.();
+  if (!snapshot || !Array.isArray(snapshot.assets)) return [];
+  return snapshot.assets.map((asset) => asset.id);
+}
+
+function exposeGlobals(engine, marginApi, insiderApi, upgradesApi) {
   window.ttm = Object.freeze({
-    ...api,
-    margin: Object.freeze({ ...margin }),
-    insider: Object.freeze({ ...insider }),
-    upgrades: Object.freeze({ ...upgrades }),
-    applyInsiderBoost: insider.applyInsiderBoost,
+    engine,
+    margin: Object.freeze({ ...marginApi }),
+    insider: Object.freeze({ ...insiderApi }),
+    upgrades: Object.freeze({ ...upgradesApi })
   });
 }
 
-export function init({ state, getPortfolioValue, getAssetIds, onTick } = {}) {
-  // Fallback state if none provided, to avoid crashes during setup
-  if (!state) {
-    state = window.state || (window.state = { cash: 0 });
-  }
-  window.ttm = { state }; // temp handle for UI callbacks using window.ttm.state
-
-  // Hydrate slices
-  const loaded = loadSlices();
-  ensureUpgradeState(state);
-  ensureMarginState(state);
-  ensureInsiderState(state);
-  Object.assign(state.upgrades, loaded.upgrades || {});
-  Object.assign(state.margin, loaded.margin || {});
-  Object.assign(state.insider, loaded.insider || {});
-
-  // Initial UI
-  renderUpgradeShop(state);
-  updateInsiderBanner(state);
-  renderHudPatch(state, (getPortfolioValue || defaultGetPortfolioValue)());
-
-  // Re-render shop on change
-  window.addEventListener("ttm:stateChanged", () => {
-    renderUpgradeShop(state);
-    saveSlices(state);
-  });
-
-  // Tick binding
-  const getPV = getPortfolioValue || defaultGetPortfolioValue;
-  const getIds = getAssetIds || defaultGetAssetIds;
-
-  if (onTick && typeof onTick === "function") {
-    // Host loop will call us each tick
-    onTick(() => tickOnce(state, getPV, getIds));
-  } else {
-    // Fallback: our own 1s interval
-    setInterval(() => tickOnce(state, getPV, getIds), 1000);
+export function init(engine, {
+  getPortfolioValue,
+  getAssetIds
+} = {}) {
+  if (!engine || typeof engine.getState !== "function") {
+    throw new Error("featurePack.init requires a game engine instance");
   }
 
-  // Finalize global API
-  exposeGlobals({ state });
+  const portfolioValueFn = typeof getPortfolioValue === "function"
+    ? (state) => getPortfolioValue(state ?? engine.getState())
+    : (state) => defaultGetPortfolioValue(engine, state);
+
+  const assetIdsFn = typeof getAssetIds === "function"
+    ? (state) => getAssetIds(state ?? engine.getState())
+    : (state) => defaultGetAssetIds(engine, state);
+
+  const marginApi = registerMargin(engine);
+  const insiderApi = registerInsider(engine, {
+    getAssetIds: (state) => assetIdsFn(state)
+  });
+  const upgradesApi = registerUpgrades(engine);
+
+  const renderExtras = (state) => {
+    const snapshot = state ?? engine.getState();
+    renderUpgradeShop(snapshot);
+    updateInsiderBanner(snapshot);
+    renderHudPatch(snapshot, portfolioValueFn(snapshot));
+  };
+
+  renderExtras(engine.getState());
+
+  const offRender = engine.onRender((currentState) => {
+    renderExtras(currentState);
+  });
+
+  const offState = engine.onStateChange((currentState) => {
+    renderUpgradeShop(currentState);
+  });
+
+  exposeGlobals(engine, marginApi, insiderApi, upgradesApi);
+
+  return function cleanup() {
+    if (typeof offRender === "function") offRender();
+    if (typeof offState === "function") offState();
+  };
 }
 
-// Auto-init if desired globals exist
-if (document.readyState !== "loading") {
-  // Do not auto-init if window.__TTM_NO_AUTO__ is set
-  if (!window.__TTM_NO_AUTO__) init({});
-} else {
-  document.addEventListener("DOMContentLoaded", () => {
-    if (!window.__TTM_NO_AUTO__) init({});
-  });
-}
+export default { init };


### PR DESCRIPTION
## Summary
- add a reusable `gameEngine` module with save/load helpers and lifecycle hook registration
- refactor `main.js` to bootstrap the engine, drive ticks/day ends, and centralize UI rendering and trading actions
- update feature modules and the feature pack to register against the engine and expose their APIs for other consumers

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68cad3b901c8832aac33da1c47d0cc70