### PR TITLE
Add meta progression systems and run summaries

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -176,3 +176,33 @@ body{
 #insider-banner { position: sticky; top: 0; padding: 6px 8px; border-bottom: 1px solid #333; }
 #insider-banner.hidden { display: none; }
 
+/* Meta progression overlay */
+.meta-layer{position:fixed;inset:0;display:none;align-items:center;justify-content:center;padding:20px;background:rgba(7,11,20,.88);z-index:12000}
+.meta-layer.show{display:flex}
+.meta-dialog{width:min(900px,95vw);max-height:92vh;overflow:auto;background:linear-gradient(180deg,#0c1324,#090f1b);border:1px solid var(--line);border-radius:18px;box-shadow:0 24px 60px rgba(0,0,0,.55);padding:24px;position:relative;display:flex;flex-direction:column;gap:18px}
+.meta-dialog__header{display:flex;justify-content:space-between;align-items:center;gap:16px}
+.meta-balance{font-weight:600;color:var(--accent-2)}
+.meta-dialog__body{display:grid;gap:16px;grid-template-columns:repeat(auto-fit,minmax(260px,1fr))}
+.meta-summary,.meta-history,.meta-upgrades{background:#0b1426;border:1px solid #1f2937;border-radius:14px;padding:16px;display:flex;flex-direction:column;gap:12px}
+.meta-summary h3,.meta-history h3,.meta-upgrades h3{margin:0;font-size:16px}
+.meta-stats{list-style:none;margin:0;padding:0;display:grid;gap:8px}
+.meta-stats li{display:flex;justify-content:space-between;font-size:13px;color:var(--muted)}
+.meta-stats li strong{color:var(--text)}
+.meta-reward{font-weight:600;color:var(--accent-2)}
+.meta-history-list{list-style:none;margin:0;padding:0;display:grid;gap:8px}
+.meta-history-list li{display:flex;justify-content:space-between;gap:12px;padding:10px 12px;border:1px solid #1f2937;border-radius:10px;background:#0f1a2c;font-size:13px}
+.meta-upgrade-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px}
+.meta-upgrade-card{border:1px solid #1f2937;border-radius:12px;background:#111b30;padding:12px;display:flex;flex-direction:column;gap:10px}
+.meta-upgrade-card.locked{opacity:.65}
+.meta-upgrade-card.maxed{border-color:#2d3b5a}
+.meta-upgrade-card h4{margin:0;display:flex;justify-content:space-between;align-items:center;font-size:15px}
+.meta-upgrade-level{font-size:12px;color:var(--muted)}
+.meta-upgrade-preview{font-size:12px;color:var(--muted)}
+.meta-upgrade-meta{display:flex;flex-wrap:wrap;gap:12px;font-size:12px;color:var(--muted)}
+.meta-upgrade-actions{display:flex;justify-content:flex-end}
+.meta-dialog__footer{display:flex;justify-content:flex-end;gap:12px}
+.meta-close{position:absolute;top:12px;right:12px;background:none;border:0;color:var(--muted);font-size:20px;cursor:pointer}
+.meta-close:hover{color:var(--text)}
+.meta-divider{border-top:1px solid #1f2937;margin:4px 0 8px}
+.meta-layer .empty{color:var(--muted);font-size:13px}
+

--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
         <button id="btn-start" class="btn btn-primary">Start</button>
         <button id="btn-end" class="btn">End Day</button>
         <button id="btn-reset" class="btn btn-danger">Reset</button>
+        <button id="btn-meta" class="btn">Mission Control</button>
         <span class="hint">Autosaves locally. No crypto wallet required. You're welcome.</span>
       </div>
     </div>
@@ -126,6 +127,25 @@
     </section>
 
   </main>
+
+  <div id="meta-layer" class="meta-layer" aria-hidden="true">
+    <div class="meta-dialog" role="dialog" aria-modal="true" aria-labelledby="meta-title">
+      <button id="btn-meta-close" class="meta-close" aria-label="Close mission control">×</button>
+      <header class="meta-dialog__header">
+        <h2 id="meta-title">Mission Control</h2>
+        <div class="meta-balance">Research Credits: <span id="meta-balance">0</span></div>
+      </header>
+      <div class="meta-dialog__body">
+        <section class="meta-summary" id="meta-summary"></section>
+        <section class="meta-history" id="meta-history"></section>
+        <section class="meta-upgrades" id="meta-upgrades"></section>
+      </div>
+      <footer class="meta-dialog__footer">
+        <button id="btn-meta-start" class="btn btn-primary">Launch New Run</button>
+        <button id="btn-meta-resume" class="btn">Resume Run</button>
+      </footer>
+    </div>
+  </div>
 
   <footer class="app-footer">
     <p>Prototype v0.1. Prices are simulated. If you lose money here, that’s on your decision-making, not the physics engine.</p>

--- a/js/core/eventScheduler.js
+++ b/js/core/eventScheduler.js
@@ -71,13 +71,20 @@ function normalizePhase(definition) {
   return [DEFAULT_PHASE];
 }
 
-function createEventScheduler({ engine, logFeed, applyEffect, random = Math.random } = {}) {
+function createEventScheduler({ engine, logFeed, applyEffect, random = Math.random, allowedEvents = null } = {}) {
   if (!engine) throw new Error("eventScheduler requires an engine instance");
   if (typeof logFeed !== "function") throw new Error("eventScheduler requires a logFeed handler");
   if (typeof applyEffect !== "function") throw new Error("eventScheduler requires an applyEffect handler");
 
+  const allowSet = Array.isArray(allowedEvents)
+    ? new Set(allowedEvents)
+    : allowedEvents instanceof Set
+      ? allowedEvents
+      : null;
+
   const definitionPhases = new Map();
   for (const def of EVENT_DEFINITIONS) {
+    if (allowSet && !allowSet.has(def.id)) continue;
     definitionPhases.set(def.id, normalizePhase(def));
   }
 
@@ -166,6 +173,7 @@ function createEventScheduler({ engine, logFeed, applyEffect, random = Math.rand
 
   function evaluatePhase(state, phase) {
     for (const def of EVENT_DEFINITIONS) {
+      if (allowSet && !allowSet.has(def.id)) continue;
       const phases = definitionPhases.get(def.id) ?? [DEFAULT_PHASE];
       if (!phases.includes(phase)) continue;
       evaluateDefinition(state, def, phase);

--- a/js/core/metaProgression.js
+++ b/js/core/metaProgression.js
@@ -1,0 +1,245 @@
+import { CORE_ASSET_IDS, ASSET_DEFS } from "./gameEngine.js";
+import { BASE_EVENT_IDS } from "../content/events.js";
+
+export const META_STORAGE_KEY = "ttm_v0_meta";
+export const META_CURRENCY_SYMBOL = "RC";
+
+const META_ASSET_IDS = ASSET_DEFS.filter((def) => def.unlock === "global-access").map((def) => def.id);
+const ADVANCED_EVENT_IDS = ["energy-crunch", "global-stimulus"];
+
+const META_UPGRADES = [
+  {
+    id: "seed-funding",
+    name: "Seed Funding",
+    description: "+$2,500 starting cash per level.",
+    cost: 25,
+    maxLevel: 3,
+    requires: [],
+    preview(level) {
+      return `Starting cash +$${(level * 2500).toLocaleString()}`;
+    }
+  },
+  {
+    id: "risk-desk",
+    name: "Risk Desk",
+    description: "Reduce baseline volatility by 5% per level and add a small positive drift.",
+    cost: 40,
+    maxLevel: 2,
+    requires: [{ id: "seed-funding", level: 1 }],
+    preview(level) {
+      const reduction = (level * 5).toFixed(0);
+      return `Volatility -${reduction}% · Drift boost +${(level * 0.03).toFixed(2)}%`;
+    }
+  },
+  {
+    id: "global-access",
+    name: "Global Access",
+    description: "Unlock renewable, energy and AI asset classes.",
+    cost: 60,
+    maxLevel: 1,
+    requires: [{ id: "seed-funding", level: 2 }],
+    preview() {
+      return `Adds ${META_ASSET_IDS.join(", ")}`;
+    }
+  },
+  {
+    id: "scenario-lab",
+    name: "Scenario Lab",
+    description: "Unlock advanced macro event arcs with richer rewards.",
+    cost: 70,
+    maxLevel: 1,
+    requires: [{ id: "risk-desk", level: 1 }],
+    preview() {
+      return "Enables advanced macro scenarios";
+    }
+  }
+];
+
+const getUpgradeDef = (id) => META_UPGRADES.find((def) => def.id === id) || null;
+
+export function createInitialMetaState() {
+  return {
+    currency: 0,
+    lifetime: {
+      runs: 0,
+      bestNetWorth: 0,
+      totalProfit: 0,
+      totalMeta: 0
+    },
+    upgrades: {},
+    lastSummary: null
+  };
+}
+
+export function loadMetaState({ storageKey = META_STORAGE_KEY } = {}) {
+  try {
+    const raw = localStorage.getItem(storageKey);
+    if (!raw) return createInitialMetaState();
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return createInitialMetaState();
+    const meta = createInitialMetaState();
+    meta.currency = Number.isFinite(parsed.currency) ? parsed.currency : meta.currency;
+    if (parsed.lifetime && typeof parsed.lifetime === "object") {
+      meta.lifetime = {
+        runs: Number.isFinite(parsed.lifetime.runs) ? parsed.lifetime.runs : 0,
+        bestNetWorth: Number.isFinite(parsed.lifetime.bestNetWorth) ? parsed.lifetime.bestNetWorth : 0,
+        totalProfit: Number.isFinite(parsed.lifetime.totalProfit) ? parsed.lifetime.totalProfit : 0,
+        totalMeta: Number.isFinite(parsed.lifetime.totalMeta) ? parsed.lifetime.totalMeta : 0
+      };
+    }
+    meta.upgrades = parsed.upgrades && typeof parsed.upgrades === "object" ? { ...parsed.upgrades } : {};
+    meta.lastSummary = parsed.lastSummary && typeof parsed.lastSummary === "object" ? { ...parsed.lastSummary } : null;
+    return meta;
+  } catch (error) {
+    console.warn("ttm:meta:load", error);
+    return createInitialMetaState();
+  }
+}
+
+export function saveMetaState(meta, { storageKey = META_STORAGE_KEY } = {}) {
+  if (!meta) return;
+  try {
+    localStorage.setItem(storageKey, JSON.stringify(meta));
+  } catch (error) {
+    console.warn("ttm:meta:save", error);
+  }
+}
+
+export function getUpgradeLevel(meta, id) {
+  if (!meta || !meta.upgrades) return 0;
+  const level = meta.upgrades[id];
+  return Number.isFinite(level) ? Math.max(0, level) : 0;
+}
+
+function upgradeCost(def, level) {
+  if (!def) return Infinity;
+  const base = Number.isFinite(def.cost) ? def.cost : 0;
+  const factor = level + 1;
+  return Math.max(0, Math.round(base * factor));
+}
+
+function meetsRequirements(meta, def) {
+  if (!def?.requires || def.requires.length === 0) return true;
+  return def.requires.every((req) => getUpgradeLevel(meta, req.id) >= (req.level ?? 1));
+}
+
+export function canPurchaseUpgrade(meta, id) {
+  const def = getUpgradeDef(id);
+  if (!def) return false;
+  const level = getUpgradeLevel(meta, id);
+  if (level >= def.maxLevel) return false;
+  if (!meetsRequirements(meta, def)) return false;
+  return meta.currency >= upgradeCost(def, level);
+}
+
+export function purchaseUpgrade(meta, id) {
+  const def = getUpgradeDef(id);
+  if (!def || !meta) return false;
+  const level = getUpgradeLevel(meta, id);
+  if (level >= def.maxLevel) return false;
+  if (!meetsRequirements(meta, def)) return false;
+  const cost = upgradeCost(def, level);
+  if (meta.currency < cost) return false;
+  meta.currency -= cost;
+  meta.upgrades[id] = level + 1;
+  return true;
+}
+
+function requirementText(def) {
+  if (!def.requires || !def.requires.length) return "";
+  return def.requires
+    .map((req) => `${getUpgradeDef(req.id)?.name ?? req.id} L${req.level ?? 1}`)
+    .join(", ");
+}
+
+export function listMetaUpgrades(meta) {
+  const snapshot = meta ?? createInitialMetaState();
+  return META_UPGRADES.map((def) => {
+    const level = getUpgradeLevel(snapshot, def.id);
+    const maxed = level >= def.maxLevel;
+    const locked = !meetsRequirements(snapshot, def);
+    const nextCost = maxed ? null : upgradeCost(def, level);
+    const preview = !maxed && typeof def.preview === "function" ? def.preview(level + 1) : "";
+    return {
+      id: def.id,
+      name: def.name,
+      description: def.description,
+      level,
+      maxLevel: def.maxLevel,
+      locked,
+      requirement: requirementText(def),
+      nextCost,
+      preview,
+      canAfford: !maxed && !locked && snapshot.currency >= nextCost
+    };
+  });
+}
+
+export function computeRunConfig(meta) {
+  const snapshot = meta ?? createInitialMetaState();
+  const seedLevel = getUpgradeLevel(snapshot, "seed-funding");
+  const accessLevel = getUpgradeLevel(snapshot, "global-access");
+  const riskLevel = getUpgradeLevel(snapshot, "risk-desk");
+  const scenarioLevel = getUpgradeLevel(snapshot, "scenario-lab");
+
+  const startingCash = 10000 + seedLevel * 2500;
+  const assetIds = Array.from(new Set([
+    ...CORE_ASSET_IDS,
+    ...(accessLevel > 0 ? META_ASSET_IDS : [])
+  ]));
+
+  const volatilityMultiplier = riskLevel > 0 ? Math.pow(0.95, riskLevel) : 1;
+  const driftBonus = riskLevel > 0 ? riskLevel * 0.0003 : 0;
+
+  const allowedEvents = new Set(BASE_EVENT_IDS);
+  if (scenarioLevel > 0) {
+    for (const id of ADVANCED_EVENT_IDS) allowedEvents.add(id);
+  }
+
+  return {
+    startingCash,
+    assetIds,
+    market: {
+      volatilityMultiplier,
+      driftBonus
+    },
+    events: {
+      allowedIds: Array.from(allowedEvents)
+    }
+  };
+}
+
+export function calculateMetaReward(summary) {
+  if (!summary) return 0;
+  if (Number.isFinite(summary.ticks) && summary.ticks < 2) return 0;
+  const netWorth = Number.isFinite(summary.netWorth) ? summary.netWorth : 0;
+  const realized = Number.isFinite(summary.realized) ? summary.realized : 0;
+  const days = Number.isFinite(summary.days) ? summary.days : 0;
+  const base = Math.max(0, Math.floor(netWorth / 5000));
+  const profitBonus = Math.max(0, Math.floor(realized / 7500));
+  const survivalBonus = Math.max(0, Math.floor(days / 3));
+  return base + profitBonus + survivalBonus;
+}
+
+export function applyRunSummaryToMeta(meta, summary) {
+  const snapshot = meta ?? createInitialMetaState();
+  const reward = calculateMetaReward(summary);
+  snapshot.currency = Math.max(0, (snapshot.currency || 0) + reward);
+  snapshot.lifetime = snapshot.lifetime || { runs: 0, bestNetWorth: 0, totalProfit: 0, totalMeta: 0 };
+  snapshot.lifetime.runs = (snapshot.lifetime.runs || 0) + 1;
+  const netWorth = Number.isFinite(summary?.netWorth) ? summary.netWorth : 0;
+  snapshot.lifetime.bestNetWorth = Math.max(snapshot.lifetime.bestNetWorth || 0, netWorth);
+  snapshot.lifetime.totalProfit = (snapshot.lifetime.totalProfit || 0) + (Number.isFinite(summary?.realized) ? summary.realized : 0);
+  snapshot.lifetime.totalMeta = (snapshot.lifetime.totalMeta || 0) + reward;
+  if (summary) {
+    snapshot.lastSummary = { ...summary, metaReward: reward };
+  }
+  return { meta: snapshot, reward };
+}
+
+export function describeMetaUpgrade(id) {
+  const def = getUpgradeDef(id);
+  return def ? def.description : "";
+}
+
+export { META_UPGRADES };

--- a/js/core/runSummary.js
+++ b/js/core/runSummary.js
@@ -1,0 +1,193 @@
+const RUN_HISTORY_KEY = "ttm_v0_runs";
+
+export const RUN_REASON_LABELS = Object.freeze({
+  bankrupt: "Bankrupt",
+  "forced-liquidation": "Forced Liquidation",
+  retired: "Voluntary Exit",
+  completed: "Run Complete"
+});
+
+const toNumber = (value, fallback = 0) => (Number.isFinite(value) ? value : fallback);
+
+export function computePortfolioValue(state) {
+  if (!state || !Array.isArray(state.assets)) return 0;
+  let sum = 0;
+  for (const asset of state.assets) {
+    if (!asset || typeof asset.id !== "string") continue;
+    const position = state.positions?.[asset.id];
+    if (!position || !Number.isFinite(position.qty) || position.qty <= 0) continue;
+    const price = Number.isFinite(asset.price) ? asset.price : asset.prev ?? 0;
+    sum += position.qty * price;
+  }
+  return sum;
+}
+
+export function computeNetWorth(state, portfolioValue) {
+  const pv = Number.isFinite(portfolioValue) ? portfolioValue : computePortfolioValue(state);
+  const cash = toNumber(state?.cash, 0);
+  const debt = toNumber(state?.margin?.debt, 0);
+  return cash + pv - debt;
+}
+
+export function ensureRunTracker(state) {
+  if (!state) return { stats: {} };
+  if (!state.run || typeof state.run !== "object") {
+    state.run = {
+      id: `${Date.now()}`,
+      status: "active",
+      startedAt: Date.now(),
+      stats: {}
+    };
+  }
+  const run = state.run;
+  if (typeof run.id !== "string" || !run.id) run.id = `${Date.now()}`;
+  if (!Number.isFinite(run.startedAt)) run.startedAt = Date.now();
+  if (typeof run.status !== "string") run.status = "active";
+  if (!run.stats || typeof run.stats !== "object") run.stats = {};
+  const stats = run.stats;
+  if (!Number.isFinite(stats.maxNetWorth)) stats.maxNetWorth = computeNetWorth(state);
+  if (!Number.isFinite(stats.minNetWorth)) stats.minNetWorth = stats.maxNetWorth;
+  if (!Number.isFinite(stats.lastNetWorth)) stats.lastNetWorth = stats.maxNetWorth;
+  if (!Number.isFinite(stats.days)) stats.days = Number.isFinite(state?.day) ? state.day : 1;
+  if (!Number.isFinite(stats.trades)) stats.trades = 0;
+  if (!Number.isFinite(stats.buyNotional)) stats.buyNotional = 0;
+  if (!Number.isFinite(stats.sellNotional)) stats.sellNotional = 0;
+  if (!Number.isFinite(stats.maintenanceStrikes)) stats.maintenanceStrikes = 0;
+  return run;
+}
+
+export function recordTradeStats(state, { side, qty, price, notional }) {
+  const run = ensureRunTracker(state);
+  const stats = run.stats;
+  stats.trades += 1;
+  const amount = Number.isFinite(notional)
+    ? notional
+    : Number.isFinite(price) && Number.isFinite(qty)
+      ? price * qty
+      : 0;
+  if (side === "sell") {
+    stats.sellNotional += Math.max(0, amount);
+  } else {
+    stats.buyNotional += Math.max(0, amount);
+  }
+}
+
+export function updateRunStats(state, { dayTick = false } = {}) {
+  const run = ensureRunTracker(state);
+  const stats = run.stats;
+  if (run.status === "pending") run.status = "active";
+  const pv = computePortfolioValue(state);
+  const debt = toNumber(state?.margin?.debt, 0);
+  const netWorth = computeNetWorth(state, pv);
+  stats.lastPortfolioValue = pv;
+  stats.lastDebt = debt;
+  stats.lastNetWorth = netWorth;
+  stats.maxNetWorth = Math.max(stats.maxNetWorth, netWorth);
+  stats.minNetWorth = Math.min(stats.minNetWorth, netWorth);
+  stats.ticks = (stats.ticks || 0) + 1;
+  if (dayTick) stats.days = Math.max(stats.days, Number.isFinite(state?.day) ? state.day : stats.days);
+  return { portfolioValue: pv, debt, netWorth };
+}
+
+export function noteMaintenanceStrike(state, underMaintenance) {
+  const run = ensureRunTracker(state);
+  const stats = run.stats;
+  if (underMaintenance) {
+    stats.maintenanceStrikes = (stats.maintenanceStrikes || 0) + 1;
+  } else {
+    stats.maintenanceStrikes = 0;
+  }
+  return stats.maintenanceStrikes;
+}
+
+export function evaluateEndCondition(state, { netWorth, maintenanceLimit = 6 } = {}) {
+  const run = ensureRunTracker(state);
+  const stats = run.stats;
+  const worth = Number.isFinite(netWorth) ? netWorth : computeNetWorth(state);
+  const pv = Number.isFinite(stats.lastPortfolioValue) ? stats.lastPortfolioValue : computePortfolioValue(state);
+  const cash = toNumber(state?.cash, 0);
+  if (worth <= 0 || (cash <= 0 && pv <= 0)) {
+    return { id: "bankrupt", label: RUN_REASON_LABELS.bankrupt };
+  }
+  if (stats.maintenanceStrikes >= maintenanceLimit) {
+    return { id: "forced-liquidation", label: RUN_REASON_LABELS["forced-liquidation"] };
+  }
+  return null;
+}
+
+export function createRunSummary(state, { reason, metaReward = 0 } = {}) {
+  const run = ensureRunTracker(state);
+  const stats = run.stats;
+  const pv = Number.isFinite(stats.lastPortfolioValue) ? stats.lastPortfolioValue : computePortfolioValue(state);
+  const netWorth = Number.isFinite(stats.lastNetWorth) ? stats.lastNetWorth : computeNetWorth(state, pv);
+  const debt = Number.isFinite(stats.lastDebt) ? stats.lastDebt : toNumber(state?.margin?.debt, 0);
+  const realized = toNumber(state?.realized, 0);
+  const reasonId = typeof reason === "object" ? reason?.id : reason;
+  const label = typeof reason === "object"
+    ? reason.label ?? RUN_REASON_LABELS[reason.id] ?? RUN_REASON_LABELS.completed
+    : RUN_REASON_LABELS[reasonId] ?? RUN_REASON_LABELS.completed;
+
+  const summary = {
+    id: run.id,
+    reason: reasonId ?? "completed",
+    label,
+    startedAt: run.startedAt,
+    endedAt: Date.now(),
+    days: Number.isFinite(state?.day) ? state.day : stats.days ?? 0,
+    ticks: Number.isFinite(state?.tick) ? state.tick : stats.ticks ?? 0,
+    netWorth,
+    cash: toNumber(state?.cash, 0),
+    portfolioValue: pv,
+    debt,
+    realized,
+    trades: stats.trades || 0,
+    buyNotional: stats.buyNotional || 0,
+    sellNotional: stats.sellNotional || 0,
+    maxNetWorth: stats.maxNetWorth ?? netWorth,
+    minNetWorth: stats.minNetWorth ?? netWorth,
+    maintenanceStrikes: stats.maintenanceStrikes || 0,
+    metaReward
+  };
+
+  run.status = "ended";
+  run.endedAt = summary.endedAt;
+  run.reason = summary.reason;
+  run.metaReward = metaReward;
+
+  return summary;
+}
+
+export function loadRunHistory({ storageKey = RUN_HISTORY_KEY } = {}) {
+  try {
+    const raw = localStorage.getItem(storageKey);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    console.warn("ttm:runHistory:load", error);
+    return [];
+  }
+}
+
+export function saveRunSummary(summary, { storageKey = RUN_HISTORY_KEY, limit = 12 } = {}) {
+  if (!summary) return loadRunHistory({ storageKey });
+  const history = loadRunHistory({ storageKey });
+  history.unshift(summary);
+  if (history.length > limit) history.length = limit;
+  try {
+    localStorage.setItem(storageKey, JSON.stringify(history));
+  } catch (error) {
+    console.warn("ttm:runHistory:save", error);
+  }
+  return history;
+}
+
+export function clearRunHistory({ storageKey = RUN_HISTORY_KEY } = {}) {
+  try {
+    localStorage.removeItem(storageKey);
+  } catch (error) {
+    console.warn("ttm:runHistory:clear", error);
+  }
+}
+
+export { RUN_HISTORY_KEY };

--- a/js/ui/metaProgression.js
+++ b/js/ui/metaProgression.js
@@ -1,0 +1,204 @@
+import { META_CURRENCY_SYMBOL } from "../core/metaProgression.js";
+
+const refs = {};
+const handlers = {
+  onStartRun: null,
+  onResumeRun: null,
+  onPurchaseUpgrade: null,
+  onClose: null
+};
+
+const escapeHtml = (value) =>
+  String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+const formatMoney = (value) =>
+  `$${Number(value || 0).toLocaleString(undefined, {
+    maximumFractionDigits: 0
+  })}`;
+
+const formatCurrency = (value) =>
+  `${Number(value || 0).toLocaleString()} ${META_CURRENCY_SYMBOL}`;
+
+function ensureRefs() {
+  if (refs.layer) return true;
+  refs.layer = document.getElementById("meta-layer");
+  if (!refs.layer) return false;
+  refs.dialog = refs.layer.querySelector(".meta-dialog");
+  refs.balance = document.getElementById("meta-balance");
+  refs.summary = document.getElementById("meta-summary");
+  refs.history = document.getElementById("meta-history");
+  refs.upgrades = document.getElementById("meta-upgrades");
+  refs.start = document.getElementById("btn-meta-start");
+  refs.resume = document.getElementById("btn-meta-resume");
+  refs.close = document.getElementById("btn-meta-close");
+  return true;
+}
+
+function renderSummary(summary, meta) {
+  if (!refs.summary) return;
+  const lifetime = meta?.lifetime || {};
+  const lifetimeStats = [
+    { label: "Runs Completed", value: lifetime.runs ?? 0 },
+    { label: "Best Net Worth", value: formatMoney(lifetime.bestNetWorth ?? 0) },
+    { label: "Total Profit", value: formatMoney(lifetime.totalProfit ?? 0) },
+    { label: "Research Earned", value: formatCurrency(lifetime.totalMeta ?? 0) }
+  ];
+
+  let html = "<h3>Last Run</h3>";
+  if (summary) {
+    const stats = [
+      { label: "Outcome", value: summary.label },
+      { label: "Days Survived", value: summary.days ?? 0 },
+      { label: "Net Worth", value: formatMoney(summary.netWorth ?? 0) },
+      { label: "Realized P&L", value: formatMoney(summary.realized ?? 0) },
+      { label: "Trades", value: summary.trades ?? 0 },
+      { label: "Peak Net Worth", value: formatMoney(summary.maxNetWorth ?? 0) }
+    ];
+    html += '<ul class="meta-stats">';
+    for (const item of stats) {
+      html += `<li><span>${escapeHtml(item.label)}</span><strong>${escapeHtml(item.value)}</strong></li>`;
+    }
+    html += "</ul>";
+    html += `<div class="meta-reward">Research Earned: <strong>${escapeHtml(
+      `${summary.metaReward ?? 0} ${META_CURRENCY_SYMBOL}`
+    )}</strong></div>`;
+  } else {
+    html += '<div class="empty">Complete a run to unlock research insights.</div>';
+  }
+
+  html += '<div class="meta-divider"></div><h3>Lifetime</h3><ul class="meta-stats">';
+  for (const item of lifetimeStats) {
+    html += `<li><span>${escapeHtml(item.label)}</span><strong>${escapeHtml(item.value)}</strong></li>`;
+  }
+  html += "</ul>";
+  refs.summary.innerHTML = html;
+}
+
+function renderHistory(history) {
+  if (!refs.history) return;
+  let html = "<h3>Run History</h3>";
+  if (!history || history.length === 0) {
+    html += '<div class="empty">No completed runs yet.</div>';
+  } else {
+    html += '<ul class="meta-history-list">';
+    history.slice(0, 5).forEach((entry) => {
+      html += `<li><span>${escapeHtml(entry.label)}</span><span>${escapeHtml(
+        formatMoney(entry.netWorth ?? 0)
+      )}</span></li>`;
+    });
+    html += "</ul>";
+  }
+  refs.history.innerHTML = html;
+}
+
+function renderUpgrades(upgrades) {
+  if (!refs.upgrades) return;
+  let html = "<h3>Meta Upgrades</h3>";
+  if (!upgrades || upgrades.length === 0) {
+    html += '<div class="empty">No upgrades available.</div>';
+  } else {
+    html += '<div class="meta-upgrade-grid">';
+    upgrades.forEach((upgrade) => {
+      const locked = upgrade.locked;
+      const maxed = upgrade.level >= upgrade.maxLevel;
+      const disabled = maxed || locked || !upgrade.canAfford;
+      const classes = ["meta-upgrade-card"];
+      if (locked) classes.push("locked");
+      if (maxed) classes.push("maxed");
+      html += `<div class="${classes.join(" ")}">`;
+      html += `<h4>${escapeHtml(upgrade.name)} <span class="meta-upgrade-level">L${upgrade.level}/${upgrade.maxLevel}</span></h4>`;
+      html += `<p>${escapeHtml(upgrade.description)}</p>`;
+      if (upgrade.preview) {
+        html += `<p class="meta-upgrade-preview">${escapeHtml(upgrade.preview)}</p>`;
+      }
+      html += '<div class="meta-upgrade-meta">';
+      if (!maxed && upgrade.nextCost != null) {
+        html += `<span>Cost: ${escapeHtml(`${upgrade.nextCost} ${META_CURRENCY_SYMBOL}`)}</span>`;
+      } else if (maxed) {
+        html += "<span>Max level reached</span>";
+      }
+      if (upgrade.requirement && upgrade.requirement.length) {
+        html += `<span>Req: ${escapeHtml(upgrade.requirement)}</span>`;
+      }
+      html += "</div>";
+      html += '<div class="meta-upgrade-actions">';
+      html += `<button class="btn btn-primary" data-upgrade-id="${escapeHtml(upgrade.id)}" ${
+        disabled ? "disabled" : ""
+      }>${escapeHtml(maxed ? "Maxed" : locked ? "Locked" : "Purchase")}</button>`;
+      html += "</div>";
+      html += "</div>";
+    });
+    html += "</div>";
+  }
+  refs.upgrades.innerHTML = html;
+}
+
+export function initMetaLayer({ onStartRun, onResumeRun, onPurchaseUpgrade, onClose } = {}) {
+  if (!ensureRefs()) return;
+  handlers.onStartRun = onStartRun;
+  handlers.onResumeRun = onResumeRun;
+  handlers.onPurchaseUpgrade = onPurchaseUpgrade;
+  handlers.onClose = onClose;
+
+  if (refs.start) {
+    refs.start.addEventListener("click", () => {
+      handlers.onStartRun && handlers.onStartRun();
+    });
+  }
+  if (refs.resume) {
+    refs.resume.addEventListener("click", () => {
+      handlers.onResumeRun && handlers.onResumeRun();
+    });
+  }
+  if (refs.close) {
+    refs.close.addEventListener("click", () => {
+      hideMetaLayer();
+      handlers.onClose && handlers.onClose();
+    });
+  }
+  if (refs.layer) {
+    refs.layer.addEventListener("click", (event) => {
+      if (event.target === refs.layer) {
+        hideMetaLayer();
+        handlers.onClose && handlers.onClose();
+      }
+    });
+  }
+  if (refs.upgrades) {
+    refs.upgrades.addEventListener("click", (event) => {
+      const button = event.target.closest("[data-upgrade-id]");
+      if (!button || button.disabled) return;
+      const id = button.getAttribute("data-upgrade-id");
+      handlers.onPurchaseUpgrade && handlers.onPurchaseUpgrade(id);
+    });
+  }
+  hideMetaLayer();
+}
+
+export function updateMetaLayer({ meta, upgrades, summary, history, allowResume, canStart }) {
+  if (!ensureRefs()) return;
+  if (refs.balance) refs.balance.textContent = formatCurrency(meta?.currency ?? 0);
+  renderSummary(summary, meta);
+  renderHistory(history);
+  renderUpgrades(upgrades);
+  if (refs.start) refs.start.disabled = !canStart;
+  if (refs.resume) refs.resume.style.display = allowResume ? "inline-flex" : "none";
+}
+
+export function showMetaLayer() {
+  if (!ensureRefs()) return;
+  refs.layer.classList.add("show");
+  refs.layer.setAttribute("aria-hidden", "false");
+}
+
+export function hideMetaLayer() {
+  if (!ensureRefs()) return;
+  refs.layer.classList.remove("show");
+  refs.layer.setAttribute("aria-hidden", "true");
+}
+


### PR DESCRIPTION
## Summary
- add run summary tracking with bankruptcy/maintenance end-state detection and persistent history
- introduce meta progression state with research currency, upgrade tree, new assets and advanced events
- implement mission control overlay for meta upgrades and run summaries and wire upgrades into engine start/configuration

## Testing
- npm test *(fails: package.json missing in project)*

------
https://chatgpt.com/codex/tasks/task_e_68caef8bfb9c832aa3bc6674b88f6447