### PR TITLE
Refactor dashboard UI into modular controllers

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,208 +1,968 @@
-:root{
-  --bg:#0b0f1a;
-  --bg-soft:#0f172a;
-  --card:#111826;
-  --muted:#9aa4b2;
-  --text:#e5e7eb;
-  --accent:#8b5cf6;
-  --accent-2:#22d3ee;
-  --good:#10b981;
-  --bad:#ef4444;
-  --line:#1f2937;
-  --ring: 0 0 0 2px color-mix(in srgb, var(--accent) 40%, transparent);
+:root {
+  --font-sans: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  --color-bg-950: #050812;
+  --color-bg-900: #090f1f;
+  --color-surface-900: #0d1427;
+  --color-surface-800: #131b33;
+  --color-surface-700: #1a2544;
+  --color-border: #1f2947;
+  --color-border-strong: #2c3760;
+  --color-text: #f1f4ff;
+  --color-muted: #a8b1cc;
+  --color-accent: #8b5cf6;
+  --color-accent-soft: rgba(139, 92, 246, 0.12);
+  --color-good: #10b981;
+  --color-bad: #ef4444;
+  --color-warn: #f59e0b;
+  --color-info: #38bdf8;
+  --shadow-lg: 0 28px 65px rgba(5, 10, 20, 0.55);
+  --shadow-md: 0 20px 45px rgba(6, 13, 34, 0.45);
+  --shadow-sm: 0 12px 28px rgba(6, 13, 34, 0.35);
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-7: 1.75rem;
+  --space-8: 2rem;
+  --radius-sm: 0.5rem;
+  --radius-md: 0.75rem;
+  --radius-lg: 1rem;
+  --radius-xl: 1.25rem;
+  --ring: 0 0 0 2px color-mix(in srgb, var(--color-accent) 55%, transparent);
 }
 
-*{box-sizing:border-box}
-html,body{height:100%}
-body{
-  margin:0;
-  font:14px/1.35 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial,"Noto Sans","Apple Color Emoji","Segoe UI Emoji";
-  color:var(--text);
-  background:radial-gradient(1000px 600px at 70% -10%, #121a2b 0%, var(--bg) 60%);
+* {
+  box-sizing: border-box;
 }
 
-/* Header / HUD */
-.app-header{padding:16px 20px 10px;border-bottom:1px solid var(--line)}
-.app-header h1{margin:0 0 8px;font-size:20px;letter-spacing:.3px;font-weight:700}
-.hud{display:flex;flex-direction:column;gap:6px}
-.hud__row{display:flex;gap:18px;align-items:center;flex-wrap:wrap}
-.hud__row>span{color:var(--muted)}
-.hud strong{color:var(--text)}
-.hud__controls .btn{margin-right:8px}
-.hint{opacity:.7;font-size:12px}
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font: 15px/1.5 var(--font-sans);
+  background: radial-gradient(1200px 900px at 72% -10%, #131c3a 0%, var(--color-bg-950) 60%);
+  color: var(--color-text);
+}
+
+noscript {
+  display: block;
+  padding: var(--space-3) var(--space-4);
+  background: var(--color-bad);
+  color: #fff;
+  text-align: center;
+}
+
+/* Header */
+.app-header {
+  padding: var(--space-6) var(--space-7) var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  background: linear-gradient(180deg, rgba(19, 28, 58, 0.5), transparent);
+}
+
+.app-header__intro {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.app-header__title {
+  margin: 0;
+  font-size: 1.8rem;
+  letter-spacing: 0.02em;
+}
+
+.app-header__tagline {
+  margin: 0;
+  color: var(--color-muted);
+  max-width: 38rem;
+}
+
+.hud {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  background: linear-gradient(135deg, rgba(14, 22, 44, 0.8), rgba(11, 18, 36, 0.65));
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4) var(--space-5);
+  box-shadow: var(--shadow-sm);
+}
+
+.hud__metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: var(--space-3);
+}
+
+.hud-metric {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.hud-metric__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+}
+
+.hud-metric__value {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.hud-metric__value[data-tone="good"],
+.hud-metric__value--pl[data-tone="good"] {
+  color: var(--color-good);
+}
+
+.hud-metric__value[data-tone="bad"],
+.hud-metric__value--pl[data-tone="bad"] {
+  color: var(--color-bad);
+}
+
+.hud__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.hud__hint {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+/* Buttons */
+.btn {
+  appearance: none;
+  border: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
+  background: linear-gradient(180deg, rgba(17, 25, 48, 0.95), rgba(12, 20, 40, 0.95));
+  color: var(--color-text);
+  padding: 0.55rem 0.95rem;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font: inherit;
+  transition: transform 120ms ease, background 180ms ease, border-color 180ms ease;
+}
+
+.btn:hover {
+  background: linear-gradient(180deg, rgba(27, 37, 70, 0.95), rgba(14, 24, 46, 0.95));
+  border-color: color-mix(in srgb, var(--color-accent) 35%, var(--color-border));
+}
+
+.btn:active {
+  transform: translateY(1px);
+}
+
+.btn:focus-visible {
+  outline: none;
+  box-shadow: var(--ring);
+}
+
+.btn-primary {
+  background: linear-gradient(180deg, color-mix(in srgb, var(--color-accent) 25%, #141f39), #111a32);
+  border-color: color-mix(in srgb, var(--color-accent) 35%, var(--color-border));
+}
+
+.btn-danger {
+  background: linear-gradient(180deg, color-mix(in srgb, var(--color-bad) 25%, #141f39), #111822);
+  border-color: color-mix(in srgb, var(--color-bad) 35%, var(--color-border));
+}
+
+.btn-disabled,
+.btn[disabled] {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
 
 /* Layout */
-.layout{
-  display:grid;
-  grid-template-columns: minmax(420px,1fr) 420px;
-  grid-auto-rows: auto;
-  gap:18px;
-  padding:18px 20px 24px;
+.app-grid {
+  display: grid;
+  gap: var(--space-5);
+  padding: var(--space-6) var(--space-7) var(--space-8);
+  grid-template-columns: minmax(360px, 2.2fr) minmax(280px, 1.3fr) minmax(280px, 1fr);
+  grid-auto-rows: minmax(120px, auto);
+  grid-template-areas:
+    "market detail upgrades"
+    "market events upgrades"
+    "market feed meta";
 }
-@media (max-width: 980px){
-  .layout{grid-template-columns:1fr}
-  .panel--right{order:-1}
+
+.panel--market { grid-area: market; }
+.panel--detail { grid-area: detail; }
+.panel--events { grid-area: events; }
+.panel--feed { grid-area: feed; }
+.panel--upgrades { grid-area: upgrades; }
+.panel--meta-preview { grid-area: meta; }
+
+@media (max-width: 1200px) {
+  .app-grid {
+    grid-template-columns: repeat(2, minmax(260px, 1fr));
+    grid-template-areas:
+      "market market"
+      "detail events"
+      "feed upgrades"
+      "meta meta";
+  }
+}
+
+@media (max-width: 840px) {
+  .app-grid {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "market"
+      "detail"
+      "events"
+      "feed"
+      "upgrades"
+      "meta";
+  }
 }
 
 /* Panels */
-.panel{
-  background:linear-gradient(180deg, var(--bg-soft), var(--card));
-  border:1px solid var(--line);
-  border-radius:12px;
-  padding:14px;
-  box-shadow:0 10px 30px rgba(0,0,0,.25);
+.panel {
+  background: linear-gradient(180deg, rgba(17, 24, 46, 0.95), rgba(10, 16, 32, 0.96));
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  border-radius: var(--radius-xl);
+  padding: var(--space-5);
+  box-shadow: var(--shadow-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
 }
-.panel__header{display:flex;justify-content:space-between;align-items:center;margin-bottom:8px}
-.panel h2{margin:0;font-size:16px}
-.panel--feed{grid-column:1 / -1}
-.panel--events{grid-column:1 / -1}
-.panel--events-empty .event-queue{opacity:.8}
 
-.event-queue{display:flex;flex-direction:column;gap:12px}
-.event-empty{display:flex;align-items:center;justify-content:center;min-height:80px;border:1px dashed var(--line);border-radius:10px;background:#0c1224;color:var(--muted);font-size:13px}
-.event-empty .meta{color:inherit}
-.event-card{display:flex;flex-direction:column;gap:12px;background:#0b1326;border:1px solid var(--line);border-radius:12px;padding:12px 14px;box-shadow:0 12px 30px rgba(2,8,23,.35)}
-.event-card__header{display:flex;justify-content:space-between;align-items:flex-start;gap:12px}
-.event-card__title{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
-.event-card__deadline{color:var(--muted);font-size:12px}
-.event-card__asset{font-size:12px;padding:2px 8px;border-radius:999px;background:color-mix(in srgb,#38bdf8 20%,transparent);color:#bae6fd}
-.event-card__description{margin:0;color:#e2e8f0;font-size:13px;line-height:1.45}
-.event-card__choices{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:10px}
-.event-choice{display:flex;gap:12px;align-items:flex-start}
-.event-choice .btn{min-width:160px}
-.event-choice__body{flex:1;display:flex;flex-direction:column;gap:4px;font-size:13px;color:var(--muted)}
-.event-choice__body p{margin:0}
-.event-choice__reason{color:var(--bad);font-size:12px}
+.panel__header {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-4);
+  align-items: flex-start;
+}
+
+.panel__header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.panel__subtitle {
+  margin: var(--space-1) 0 0;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+  max-width: 32ch;
+}
 
 /* Market table */
-.qty-picker{display:flex;align-items:center;gap:8px;color:var(--muted)}
-.qty-picker input{
-  width:84px;padding:6px 8px;border-radius:8px;border:1px solid var(--line);
-  background:#0d1426;color:var(--text)
-}
-.table-wrap{overflow:auto;border-radius:10px;border:1px solid var(--line)}
-.table{width:100%;border-collapse:separate;border-spacing:0;min-width:720px}
-.table thead th{
-  text-align:left;font-weight:600;color:var(--muted);
-  padding:10px 12px;background:#0f1629;position:sticky;top:0;z-index:1
-}
-.table tbody td{padding:10px 12px;border-top:1px solid var(--line)}
-.table tbody tr:hover{background:rgba(139,92,246,.06)}
-.table .num{text-align:right}
-
-/* Badges + buttons */
-.badge{display:inline-block;padding:2px 8px;border-radius:999px;font-size:12px;font-weight:600}
-.badge--good{color:var(--good);background:color-mix(in srgb, var(--good) 18%, transparent)}
-.badge--bad{color:var(--bad);background:color-mix(in srgb, var(--bad) 18%, transparent)}
-.badge--neutral{color:#cbd5e1;background:#0c1224}
-
-.btn{
-  appearance:none;border:1px solid var(--line);background:#121a2b;
-  color:var(--text);padding:8px 12px;border-radius:10px;cursor:pointer;
-  transition:transform .06s ease, background .2s ease, border-color .2s
-}
-.btn:hover{background:#141f34;border-color:#2b3b58}
-.btn:active{transform:translateY(1px)}
-.btn:focus-visible{outline:none;box-shadow:var(--ring)}
-.btn-primary{
-  background:linear-gradient(180deg, color-mix(in srgb, var(--accent) 20%, #121a2b), #121a2b);
-  border-color: color-mix(in srgb, var(--accent) 40%, var(--line))
-}
-.btn-danger{
-  background:linear-gradient(180deg, color-mix(in srgb, var(--bad) 20%, #121a2b), #121a2b);
-  border-color: color-mix(in srgb, var(--bad) 40%, var(--line))
+.table-wrap {
+  position: relative;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: rgba(9, 14, 30, 0.6);
+  overflow: hidden;
 }
 
-/* Details + chart */
-.detail-card{margin-top:8px;border-top:1px solid var(--line);padding-top:10px}
-.detail-line{display:flex;justify-content:space-between;margin:6px 0;color:var(--muted)}
-.detail-line strong{color:var(--text)}
-#chart{
-  width:100%;height:auto;display:block;margin:10px 0 14px;
-  background:linear-gradient(180deg,#0c1224,#0a1020);
-  border:1px solid var(--line);border-radius:8px
+.table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  min-width: 680px;
 }
-.trade-controls{display:flex;gap:10px;align-items:center}
-.trade-controls input{
-  width:100px;padding:8px;border-radius:8px;border:1px solid var(--line);
-  background:#0d1426;color:var(--text)
-}
-.messages{margin-top:10px;min-height:22px;color:var(--muted)}
-.pl--good{color:var(--good)} .pl--bad{color:var(--bad)} .pl--neutral{color:#cbd5e1}
 
-/* Effects (selected asset) */
-.effects{margin:8px 0 6px}
-.effects__title{color:var(--muted);font-size:12px;margin-bottom:6px}
-.effects__list{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:6px}
-.effects--drivers{margin-top:12px}
-.effects--drivers .effects__title{color:#f8fafc}
-.effect{
-  display:flex;justify-content:space-between;gap:10px;
-  background:#0c1224;border:1px solid var(--line);border-radius:8px;padding:6px 8px
+.table thead th {
+  text-align: left;
+  font-weight: 600;
+  color: var(--color-muted);
+  padding: var(--space-3) var(--space-4);
+  background: rgba(13, 22, 42, 0.85);
+  position: sticky;
+  top: 0;
+  z-index: 1;
 }
-.effect .tags{display:flex;gap:6px;flex-wrap:wrap}
-.tag{padding:2px 8px;border-radius:999px;font-size:12px}
-.tag--good{color:var(--good);background:color-mix(in srgb, var(--good) 18%, transparent)}
-.tag--bad{color:var(--bad);background:color-mix(in srgb, var(--bad) 18%, transparent)}
-.tag--neutral{color:#cbd5e1;background:#0b1426}
-.tag--player{color:#38bdf8;background:color-mix(in srgb,#38bdf8 24%,transparent)}
-.tag--sentiment{color:#f97316;background:color-mix(in srgb,#f97316 22%,transparent)}
-.tag--macro{color:#facc15;background:color-mix(in srgb,#facc15 22%,transparent)}
-.tag--event{color:#fb7185;background:color-mix(in srgb,#fb7185 22%,transparent)}
-.tag--volatility{color:#a855f7;background:color-mix(in srgb,#a855f7 22%,transparent)}
-.tag--baseline{color:#94a3b8;background:color-mix(in srgb,#94a3b8 18%,transparent)}
-.tag--noise{color:#cbd5f5;background:color-mix(in srgb,#cbd5f5 12%,transparent)}
-.effect .meta{color:var(--muted);font-size:12px}
+
+.table tbody td {
+  padding: var(--space-3) var(--space-4);
+  border-top: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.table tbody tr[data-selected="true"] {
+  background: rgba(139, 92, 246, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(139, 92, 246, 0.3);
+}
+
+.table tbody tr:hover {
+  background: rgba(139, 92, 246, 0.06);
+}
+
+.table .num {
+  text-align: right;
+}
+
+.table .actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+}
+
+.table-empty {
+  position: absolute;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+  background: rgba(5, 8, 18, 0.88);
+}
+
+.table-empty:not(.is-hidden) {
+  display: flex;
+}
+
+.qty-picker {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--color-muted);
+}
+
+.qty-picker input {
+  width: 96px;
+  padding: 0.45rem 0.65rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: rgba(9, 15, 30, 0.9);
+  color: var(--color-text);
+}
+
+/* Detail panel */
+.detail-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.detail-grid {
+  display: grid;
+  gap: var(--space-3);
+  margin: 0;
+  padding: 0;
+}
+
+.detail-line {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-2);
+  color: var(--color-muted);
+}
+
+.detail-line dt {
+  font-weight: 600;
+}
+
+.detail-line dd {
+  margin: 0;
+  color: var(--color-text);
+}
+
+.detail-reason {
+  font-size: 0.9rem;
+  color: var(--color-muted);
+  max-width: 36ch;
+}
+
+.detail-reason[data-tone="good"] {
+  color: var(--color-good);
+}
+
+.detail-reason[data-tone="bad"] {
+  color: var(--color-bad);
+}
+
+.detail-reason__driver {
+  font-weight: 600;
+}
+
+.detail-reason__driver--good {
+  color: var(--color-good);
+}
+
+.detail-reason__driver--bad {
+  color: var(--color-bad);
+}
+
+.detail-panels {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.effects {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.effects__title {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+}
+
+.effects__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-2);
+}
+
+.effect {
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  border-radius: var(--radius-sm);
+  background: rgba(10, 16, 32, 0.9);
+  padding: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.effect--empty {
+  text-align: center;
+  color: var(--color-muted);
+}
+
+.effect__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.effect__meta {
+  color: var(--color-muted);
+  font-size: 0.85rem;
+}
+
+.effect__tags {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+canvas[data-element="chart"] {
+  width: 100%;
+  max-width: 100%;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  background: linear-gradient(180deg, rgba(9, 15, 30, 0.9), rgba(7, 12, 24, 0.9));
+}
+
+.trade-shell {
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+  background: rgba(10, 17, 34, 0.9);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.trade-shell__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.trade-shell__asset {
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.trade-controls {
+  display: grid;
+  grid-template-columns: auto 120px repeat(2, auto);
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.trade-controls input {
+  width: 100%;
+  padding: 0.45rem 0.6rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: rgba(8, 13, 26, 0.92);
+  color: var(--color-text);
+}
+
+.trade-confirm {
+  min-height: 1.25rem;
+  font-size: 0.9rem;
+  color: var(--color-muted);
+}
+
+.trade-confirm[data-tone="good"] {
+  color: var(--color-good);
+}
+
+.trade-confirm[data-tone="warn"] {
+  color: var(--color-warn);
+}
+
+.trade-confirm[data-tone="bad"] {
+  color: var(--color-bad);
+}
+
+.trade-confirm.is-hidden {
+  visibility: hidden;
+}
+
+/* Badges & tags */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.1rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.badge--good {
+  color: var(--color-good);
+  background: rgba(16, 185, 129, 0.18);
+}
+
+.badge--bad {
+  color: var(--color-bad);
+  background: rgba(239, 68, 68, 0.2);
+}
+
+.badge--neutral {
+  color: var(--color-muted);
+  background: rgba(148, 163, 184, 0.16);
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.tag--good { color: var(--color-good); background: rgba(16, 185, 129, 0.16); }
+.tag--bad { color: var(--color-bad); background: rgba(239, 68, 68, 0.16); }
+.tag--warn { color: var(--color-warn); background: rgba(245, 158, 11, 0.18); }
+.tag--neutral { color: var(--color-muted); background: rgba(148, 163, 184, 0.14); }
+.tag--macro { color: #facc15; background: rgba(250, 204, 21, 0.16); }
+.tag--player { color: #38bdf8; background: rgba(56, 189, 248, 0.16); }
+.tag--sentiment { color: #fb7185; background: rgba(251, 113, 133, 0.18); }
+.tag--volatility { color: #a855f7; background: rgba(168, 85, 247, 0.18); }
+
+/* Event cards */
+.event-queue {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.event-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 90px;
+  border: 1px dashed rgba(255, 255, 255, 0.06);
+  border-radius: var(--radius-md);
+  color: var(--color-muted);
+  background: rgba(10, 16, 32, 0.7);
+}
+
+.event-card {
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+  background: rgba(9, 15, 30, 0.92);
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.event-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.event-card__title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.event-card__deadline {
+  color: var(--color-muted);
+  font-size: 0.85rem;
+}
+
+.event-card__asset {
+  padding: 0.1rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.18);
+  color: #bae6fd;
+  font-size: 0.75rem;
+}
+
+.event-card__summary {
+  font-size: 0.95rem;
+  color: var(--color-info);
+}
+
+.event-card__description {
+  margin: 0;
+  color: var(--color-text);
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.event-card__choices {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-3);
+}
+
+.event-choice {
+  display: grid;
+  grid-template-columns: minmax(140px, auto) 1fr;
+  gap: var(--space-3);
+  align-items: start;
+}
+
+.event-choice__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.event-choice__body p {
+  margin: 0;
+}
+
+.event-choice__reason {
+  color: var(--color-bad);
+  font-size: 0.8rem;
+}
 
 /* Feed */
-.feed{list-style:none;margin:0;padding:0;display:grid;gap:8px;max-height:200px;overflow:auto}
-.feed li{
-  display:flex;justify-content:space-between;align-items:center;gap:10px;
-  background:#0c1224;border:1px solid var(--line);border-radius:10px;padding:8px 10px
+.feed {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-3);
 }
-.feed .left{display:flex;gap:10px;align-items:center}
-.feed .time{color:var(--muted);font-size:12px}
-.feed .right{display:flex;gap:6px;align-items:center;flex-wrap:wrap}
 
-/* Footer */
-.app-footer{padding:10px 20px 30px;color:var(--muted);text-align:center}
+.feed__item {
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  border-radius: var(--radius-lg);
+  padding: var(--space-3) var(--space-4);
+  background: rgba(9, 15, 30, 0.88);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.feed__item--good { border-color: rgba(16, 185, 129, 0.3); }
+.feed__item--bad { border-color: rgba(239, 68, 68, 0.3); }
+.feed__item--warn { border-color: rgba(245, 158, 11, 0.35); }
+
+.feed__item-head {
+  display: flex;
+  gap: var(--space-2);
+  justify-content: space-between;
+}
+
+.feed__time {
+  color: var(--color-muted);
+  font-size: 0.8rem;
+}
+
+.feed__target {
+  font-size: 0.8rem;
+  color: var(--color-info);
+}
+
+.feed__text {
+  margin: 0;
+}
+
+.feed__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.feed-empty {
+  text-align: center;
+  padding: var(--space-3);
+  color: var(--color-muted);
+  border: 1px dashed rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-md);
+}
 
 /* Upgrades */
-#panel-upgrades { padding: 8px; }
-.upgrade-card { border: 1px solid #222; padding: 8px; margin: 6px 0; border-radius: 6px; }
-.upgrade-title { font-weight: 600; }
-.upgrade-desc { font-size: 0.9rem; opacity: 0.8; margin: 4px 0 8px; }
-.upgrade-cta { display: flex; justify-content: space-between; align-items: center; }
-#insider-banner { position: sticky; top: 0; padding: 6px 8px; border-bottom: 1px solid #333; }
-#insider-banner.hidden { display: none; }
+.upgrade-grid {
+  display: grid;
+  gap: var(--space-3);
+}
 
-/* Meta progression overlay */
-.meta-layer{position:fixed;inset:0;display:none;align-items:center;justify-content:center;padding:20px;background:rgba(7,11,20,.88);z-index:12000}
-.meta-layer.show{display:flex}
-.meta-dialog{width:min(900px,95vw);max-height:92vh;overflow:auto;background:linear-gradient(180deg,#0c1324,#090f1b);border:1px solid var(--line);border-radius:18px;box-shadow:0 24px 60px rgba(0,0,0,.55);padding:24px;position:relative;display:flex;flex-direction:column;gap:18px}
-.meta-dialog__header{display:flex;justify-content:space-between;align-items:center;gap:16px}
-.meta-balance{font-weight:600;color:var(--accent-2)}
-.meta-dialog__body{display:grid;gap:16px;grid-template-columns:repeat(auto-fit,minmax(260px,1fr))}
-.meta-summary,.meta-history,.meta-upgrades{background:#0b1426;border:1px solid #1f2937;border-radius:14px;padding:16px;display:flex;flex-direction:column;gap:12px}
-.meta-summary h3,.meta-history h3,.meta-upgrades h3{margin:0;font-size:16px}
-.meta-stats{list-style:none;margin:0;padding:0;display:grid;gap:8px}
-.meta-stats li{display:flex;justify-content:space-between;font-size:13px;color:var(--muted)}
-.meta-stats li strong{color:var(--text)}
-.meta-reward{font-weight:600;color:var(--accent-2)}
-.meta-history-list{list-style:none;margin:0;padding:0;display:grid;gap:8px}
-.meta-history-list li{display:flex;justify-content:space-between;gap:12px;padding:10px 12px;border:1px solid #1f2937;border-radius:10px;background:#0f1a2c;font-size:13px}
-.meta-upgrade-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px}
-.meta-upgrade-card{border:1px solid #1f2937;border-radius:12px;background:#111b30;padding:12px;display:flex;flex-direction:column;gap:10px}
-.meta-upgrade-card.locked{opacity:.65}
-.meta-upgrade-card.maxed{border-color:#2d3b5a}
-.meta-upgrade-card h4{margin:0;display:flex;justify-content:space-between;align-items:center;font-size:15px}
-.meta-upgrade-level{font-size:12px;color:var(--muted)}
-.meta-upgrade-preview{font-size:12px;color:var(--muted)}
-.meta-upgrade-meta{display:flex;flex-wrap:wrap;gap:12px;font-size:12px;color:var(--muted)}
-.meta-upgrade-actions{display:flex;justify-content:flex-end}
-.meta-dialog__footer{display:flex;justify-content:flex-end;gap:12px}
-.meta-close{position:absolute;top:12px;right:12px;background:none;border:0;color:var(--muted);font-size:20px;cursor:pointer}
-.meta-close:hover{color:var(--text)}
-.meta-divider{border-top:1px solid #1f2937;margin:4px 0 8px}
-.meta-layer .empty{color:var(--muted);font-size:13px}
+.upgrade-card {
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+  background: rgba(9, 15, 30, 0.88);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
 
+.upgrade-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.upgrade-card__price {
+  color: var(--color-info);
+  font-weight: 600;
+}
+
+.upgrade-card__desc {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.upgrade-card__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.upgrade-card--owned {
+  border-color: rgba(16, 185, 129, 0.35);
+}
+
+.upgrade-card--locked {
+  opacity: 0.65;
+}
+
+.upgrade-status {
+  font-size: 0.9rem;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  background: rgba(19, 28, 58, 0.75);
+}
+
+.upgrade-status[data-tone="good"] {
+  color: var(--color-good);
+}
+
+.upgrade-status[data-tone="warn"] {
+  color: var(--color-warn);
+}
+
+.upgrade-status.is-hidden {
+  display: none;
+}
+
+.insider-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(56, 189, 248, 0.25);
+  background: rgba(13, 24, 46, 0.65);
+  color: #e0f2fe;
+  font-size: 0.95rem;
+}
+
+.insider-banner.hidden {
+  display: none;
+}
+
+.insider-banner__label {
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.insider-banner__timer {
+  font-variant-numeric: tabular-nums;
+}
+
+/* Meta preview */
+.meta-preview {
+  border: 1px dashed rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+  color: var(--color-muted);
+  font-size: 0.95rem;
+  background: rgba(9, 15, 30, 0.65);
+}
+
+/* Footer */
+.app-footer {
+  padding: var(--space-5) var(--space-7) var(--space-8);
+  color: var(--color-muted);
+  text-align: center;
+  font-size: 0.85rem;
+}
+
+/* Tooltips */
+[data-tooltip] {
+  position: relative;
+}
+
+[data-tooltip]:hover::after,
+[data-tooltip]:focus-visible::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  z-index: 20;
+  left: 50%;
+  bottom: 110%;
+  transform: translateX(-50%);
+  background: rgba(10, 16, 32, 0.95);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: var(--color-text);
+  padding: 0.35rem 0.6rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.75rem;
+  white-space: nowrap;
+  pointer-events: none;
+  box-shadow: var(--shadow-sm);
+}
+
+[data-tooltip]:hover::before,
+[data-tooltip]:focus-visible::before {
+  content: "";
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 6px;
+  border-style: solid;
+  border-color: rgba(10, 16, 32, 0.95) transparent transparent transparent;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* Meta progression overlay tweaks */
+.meta-layer {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-6);
+  background: rgba(4, 8, 18, 0.88);
+  z-index: 12000;
+}
+
+.meta-layer.show {
+  display: flex;
+}
+
+.meta-dialog {
+  width: min(900px, 95vw);
+  max-height: 92vh;
+  overflow: auto;
+  background: linear-gradient(180deg, rgba(14, 22, 44, 0.96), rgba(9, 14, 28, 0.96));
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 1.5rem;
+  box-shadow: var(--shadow-lg);
+  padding: var(--space-6);
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.meta-dialog__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.meta-balance {
+  font-weight: 600;
+  color: var(--color-info);
+}
+
+.meta-dialog__body {
+  display: grid;
+  gap: var(--space-3);
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.meta-summary,
+.meta-history,
+.meta-upgrades {
+  background: rgba(10, 16, 32, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.meta-summary h3,
+.meta-history h3,
+.meta-upgrades h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.meta-history-list,
+.meta-stats {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-2);
+}
+
+.meta-history-list li,
+.meta-stats li {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-2);
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.meta-history-list li strong,
+.meta-stats li strong {
+  color: var(--color-text);
+}

--- a/css/upgrades.css
+++ b/css/upgrades.css
@@ -1,12 +1,71 @@
-/* Upgrade pack styles. Non-invasive. */
-#panel-upgrades { padding: 8px; }
-.upgrade-card { border: 1px solid #222; padding: 8px; margin: 6px 0; border-radius: 6px; }
-.upgrade-title { font-weight: 600; }
-.upgrade-desc { font-size: 0.9rem; opacity: 0.8; margin: 4px 0 8px; }
-.upgrade-cta { display: flex; justify-content: space-between; align-items: center; }
-#insider-banner { position: sticky; top: 0; padding: 6px 8px; border-bottom: 1px solid #333; background: #111; }
-#insider-banner.hidden { display: none; }
+/* Feature pack + optional overlays adopt the design tokens from styles.css */
+:root {
+  --upg-surface: rgba(12, 20, 38, 0.95);
+  --upg-border: rgba(255, 255, 255, 0.08);
+  --upg-text: #f1f4ff;
+  --upg-muted: #9aa6c8;
+}
 
-#ttm-hud { position: fixed; right: 8px; bottom: 8px; z-index: 50; }
-#ttm-hud .ttm-hud { background: rgba(0,0,0,0.6); padding: 8px 10px; border: 1px solid #222; border-radius: 6px; font-size: 12px; line-height: 1.3; }
-#ttm-hud .ttm-hud div { white-space: nowrap; }
+#panel-upgrades {
+  padding: var(--space-3, 0.75rem);
+}
+
+.upgrade-card {
+  border: 1px solid var(--upg-border);
+  padding: var(--space-3, 0.75rem);
+  margin: var(--space-2, 0.5rem) 0;
+  border-radius: var(--radius-md, 0.75rem);
+  background: var(--upg-surface);
+  color: var(--upg-text);
+}
+
+.upgrade-title {
+  font-weight: 600;
+}
+
+.upgrade-desc {
+  font-size: 0.9rem;
+  opacity: 0.8;
+  margin: 0.35rem 0 0.6rem;
+}
+
+.upgrade-cta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+#insider-banner {
+  position: sticky;
+  top: 0;
+  padding: 0.75rem 0.9rem;
+  border-bottom: 1px solid var(--upg-border);
+  background: rgba(14, 24, 46, 0.85);
+  color: var(--upg-text);
+}
+
+#insider-banner.hidden {
+  display: none;
+}
+
+#ttm-hud {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 50;
+}
+
+#ttm-hud .ttm-hud {
+  background: rgba(5, 9, 20, 0.75);
+  padding: 0.75rem 0.9rem;
+  border: 1px solid var(--upg-border);
+  border-radius: var(--radius-md, 0.75rem);
+  font-size: 0.75rem;
+  line-height: 1.3;
+  color: var(--upg-text);
+  box-shadow: 0 12px 28px rgba(5, 9, 20, 0.45);
+}
+
+#ttm-hud .ttm-hud div {
+  white-space: nowrap;
+}

--- a/index.html
+++ b/index.html
@@ -11,121 +11,170 @@
   <noscript>This game needs JavaScript. Which, yes, is still a thing in 2025.</noscript>
 
   <header class="app-header">
-    <h1>🚀 To The Moon — Trading Sim</h1>
-    <div class="hud" role="status" aria-live="polite">
-      <div class="hud__row">
-        <span>Day <strong id="hud-day">1</strong></span>
-        <span>Cash <strong id="hud-cash">$10,000.00</strong></span>
-        <span>Equity <strong id="hud-equity">$10,000.00</strong></span>
-        <span>P&amp;L <strong id="hud-pl" class="pl--neutral">$0.00</strong></span>
+    <div class="app-header__intro">
+      <h1 class="app-header__title">🚀 To The Moon — Trading Sim</h1>
+      <p class="app-header__tagline">Prototype command deck. Built for fast iteration and questionable decisions.</p>
+    </div>
+    <div class="hud" data-module="hud" role="status" aria-live="polite">
+      <div class="hud__metrics">
+        <div class="hud-metric">
+          <span class="hud-metric__label">Day</span>
+          <strong class="hud-metric__value" data-field="day">1</strong>
+        </div>
+        <div class="hud-metric">
+          <span class="hud-metric__label">Cash</span>
+          <strong class="hud-metric__value" data-field="cash">$10,000.00</strong>
+        </div>
+        <div class="hud-metric">
+          <span class="hud-metric__label">Equity</span>
+          <strong class="hud-metric__value" data-field="equity">$10,000.00</strong>
+        </div>
+        <div class="hud-metric">
+          <span class="hud-metric__label">P&amp;L</span>
+          <strong class="hud-metric__value hud-metric__value--pl" data-field="pl">$0.00</strong>
+        </div>
       </div>
-      <div class="hud__row hud__controls">
-        <button id="btn-start" class="btn btn-primary">Start</button>
-        <button id="btn-end" class="btn">End Day</button>
-        <button id="btn-reset" class="btn btn-danger">Reset</button>
-        <button id="btn-meta" class="btn">Mission Control</button>
-        <span class="hint">Autosaves locally. No crypto wallet required. You're welcome.</span>
+      <div class="hud__actions">
+        <button class="btn btn-primary" data-action="toggle-run" data-tooltip="Start or pause the market clock">Start</button>
+        <button class="btn" data-action="end-day" data-tooltip="Advance to the next trading day">End Day</button>
+        <button class="btn btn-danger" data-action="reset-run" data-tooltip="Retire this run and cash out">Reset</button>
+        <button class="btn" data-action="open-meta" data-tooltip="Open Mission Control to spend research credits">Mission Control</button>
       </div>
+      <span class="hud__hint">Autosaves locally. No crypto wallet required. You're welcome.</span>
     </div>
   </header>
 
-  <main class="layout">
-    <section class="panel panel--left">
-      <div class="panel__header">
-        <h2>Market</h2>
-        <div class="qty-picker">
-          <label for="qty-global">Default Qty</label>
-          <input id="qty-global" type="number" min="1" step="1" value="10" />
+  <main id="dashboard" class="app-grid">
+    <section class="panel panel--market" data-module="market">
+      <header class="panel__header">
+        <div>
+          <h2>Market Radar</h2>
+          <p class="panel__subtitle">Live tickers, quick actions, and the pulse of chaos.</p>
         </div>
-      </div>
-
+        <div class="qty-picker" data-tooltip="Default quantity used for quick trades from the market table">
+          <label for="qty-global">Default Qty</label>
+          <input id="qty-global" data-element="default-qty" type="number" min="1" step="1" value="10" />
+        </div>
+      </header>
       <div class="table-wrap">
         <table class="table" aria-label="Market table">
           <thead>
             <tr>
-              <th>Ticker</th>
-              <th>Name</th>
-              <th class="num">Price</th>
-              <th class="num">Δ%</th>
-              <th class="num">Position</th>
-              <th class="num">Unrl. P&amp;L</th>
-              <th class="num">Actions</th>
+              <th scope="col">Ticker</th>
+              <th scope="col">Name</th>
+              <th scope="col" class="num">Price</th>
+              <th scope="col" class="num">Δ%</th>
+              <th scope="col" class="num">Position</th>
+              <th scope="col" class="num">Unrl. P&amp;L</th>
+              <th scope="col" class="num">Actions</th>
             </tr>
           </thead>
-          <tbody id="market-body">
-            <!-- rows inserted by JS -->
-          </tbody>
+          <tbody data-region="market-body"></tbody>
         </table>
+        <div class="table-empty" data-element="market-empty">No assets yet. Launch a run to load the market.</div>
       </div>
     </section>
 
-    <aside class="panel panel--right">
-      <h2 id="detail-title">Details</h2>
-
+    <section class="panel panel--detail" data-module="asset-detail">
+      <header class="panel__header">
+        <div>
+          <h2 data-element="detail-title">Asset Details</h2>
+          <p class="panel__subtitle">Inspect drivers and positions before you pull the trigger.</p>
+        </div>
+        <div class="detail-reason" data-element="detail-reason" aria-live="polite">Select an asset to inspect market context.</div>
+      </header>
       <div class="detail-card">
-        <div class="detail-line">
-          <span>Asset</span>
-          <strong id="detail-asset">—</strong>
-        </div>
-        <div class="detail-line">
-          <span>Price</span>
-          <strong id="detail-price">—</strong>
-        </div>
-        <div class="detail-line">
-          <span>Your Position</span>
-          <strong id="detail-position">—</strong>
+        <dl class="detail-grid">
+          <div class="detail-line">
+            <dt>Asset</dt>
+            <dd data-element="detail-asset">—</dd>
+          </div>
+          <div class="detail-line">
+            <dt>Price</dt>
+            <dd data-element="detail-price">—</dd>
+          </div>
+          <div class="detail-line">
+            <dt>Your Position</dt>
+            <dd data-element="detail-position">—</dd>
+          </div>
+        </dl>
+
+        <div class="detail-panels">
+          <section class="effects" aria-label="Active effects">
+            <div class="effects__title">Active Effects</div>
+            <ul class="effects__list" data-element="effects-list"></ul>
+          </section>
+
+          <section class="effects effects--drivers" aria-label="Price drivers">
+            <div class="effects__title">Price Drivers</div>
+            <ul class="effects__list" data-element="drivers-list"></ul>
+          </section>
         </div>
 
-        <div class="effects">
-          <div class="effects__title">Active Effects</div>
-          <ul id="effects-list" class="effects__list"></ul>
-        </div>
+        <canvas data-element="chart" width="560" height="240" aria-label="Price chart"></canvas>
 
-        <div class="effects effects--drivers">
-          <div class="effects__title">Price Drivers</div>
-          <ul id="drivers-list" class="effects__list"></ul>
-        </div>
-
-        <canvas id="chart" width="560" height="240" aria-label="Price chart"></canvas>
-
-        <div class="trade-controls">
-          <label for="trade-qty">Qty</label>
-          <input id="trade-qty" type="number" min="1" step="1" value="10" />
-          <button id="btn-buy" class="btn btn-primary">Buy</button>
-          <button id="btn-sell" class="btn">Sell</button>
-        </div>
-
-        <div id="messages" class="messages" aria-live="polite"></div>
+        <section class="trade-shell" data-module="trade-controls">
+          <header class="trade-shell__header">
+            <h3>Trade Controls</h3>
+            <span class="trade-shell__asset" data-element="trade-asset">Select an asset from the market table.</span>
+          </header>
+          <div class="trade-controls">
+            <label for="trade-qty">Qty</label>
+            <input id="trade-qty" data-element="trade-qty" type="number" min="1" step="1" value="10" />
+            <button class="btn btn-primary" data-action="trade-buy" data-tooltip="Submit a buy order for the selected asset">Buy</button>
+            <button class="btn" data-action="trade-sell" data-tooltip="Submit a sell order for the selected asset">Sell</button>
+          </div>
+          <div class="trade-confirm is-hidden" data-element="trade-message" role="status" aria-live="polite"></div>
+        </section>
       </div>
+    </section>
+
+    <section class="panel panel--events" data-module="events">
+      <header class="panel__header">
+        <div>
+          <h2>Situation Room</h2>
+          <p class="panel__subtitle">Story events with lasting market impact.</p>
+        </div>
+      </header>
+      <div class="event-queue" data-region="event-list">
+        <div class="event-empty" data-element="events-empty"><span class="meta">No active scenarios.</span></div>
+      </div>
+    </section>
+
+    <section class="panel panel--feed" data-module="news">
+      <header class="panel__header">
+        <div>
+          <h2>News Feed</h2>
+          <p class="panel__subtitle">Events apply temporary market effects. Because vibes move prices.</p>
+        </div>
+      </header>
+      <ul class="feed" data-region="news-list" aria-live="polite"></ul>
+      <div class="feed-empty" data-element="news-empty">Waiting for market chatter…</div>
+    </section>
+
+    <aside class="panel panel--upgrades" data-module="upgrade-shop">
+      <header class="panel__header">
+        <div>
+          <h2>Upgrade Hangar</h2>
+          <p class="panel__subtitle">Invest in tech that rewrites the rules mid-run.</p>
+        </div>
+      </header>
+      <div id="insider-banner" class="insider-banner hidden" role="status" aria-live="polite"></div>
+      <div class="upgrade-status is-hidden" data-element="upgrade-status" aria-live="polite"></div>
+      <div class="upgrade-grid" data-region="upgrade-list"></div>
     </aside>
 
-    <section id="event-panel" class="panel panel--events">
-      <div class="panel__header">
-        <h2>Situation Room</h2>
-        <span class="hint">Make the call before the market does.</span>
+    <aside class="panel panel--meta-preview">
+      <header class="panel__header">
+        <div>
+          <h2>Mission Brief</h2>
+          <p class="panel__subtitle">Space reserved for tutorials, goals, or meta progression.</p>
+        </div>
+      </header>
+      <div class="meta-preview">
+        <p>Coming soon: guideposts for your next moonshot. Feature packs can mount here without reworking the dashboard layout.</p>
       </div>
-      <div id="event-queue" class="event-queue">
-        <div class="event-empty"><span class="meta">No active scenarios.</span></div>
-      </div>
-    </section>
-
-    <section class="panel panel--feed">
-      <div class="panel__header">
-        <h2>News Feed</h2>
-        <span class="hint">Events apply temporary market effects. Because vibes move prices.</span>
-      </div>
-      <ul id="feed" class="feed" aria-live="polite"></ul>
-    </section>
-    
-    <!-- Insider banner -->
-    <div id="insider-banner" class="hidden"></div>
-    
-    <!-- Upgrade Shop -->
-    <section id="panel-upgrades">
-      <h3>Upgrades</h3>
-      <div id="upgrades"></div>
-    </section>
-
+    </aside>
   </main>
 
   <div id="meta-layer" class="meta-layer" aria-hidden="true">

--- a/js/featurePack.js
+++ b/js/featurePack.js
@@ -58,7 +58,12 @@ export function init(engine, {
 
   const renderExtras = (state) => {
     const snapshot = state ?? engine.getState();
-    renderUpgradeShop(snapshot);
+    const upgradesUi = window.__TTM_UI__?.upgrades;
+    if (upgradesUi && typeof upgradesUi.render === "function") {
+      upgradesUi.render(snapshot);
+    } else {
+      renderUpgradeShop(snapshot);
+    }
     updateInsiderBanner(snapshot);
     renderHudPatch(snapshot, portfolioValueFn(snapshot));
   };
@@ -70,7 +75,12 @@ export function init(engine, {
   });
 
   const offState = engine.onStateChange((currentState) => {
-    renderUpgradeShop(currentState);
+    const upgradesUi = window.__TTM_UI__?.upgrades;
+    if (upgradesUi && typeof upgradesUi.render === "function") {
+      upgradesUi.render(currentState);
+    } else {
+      renderUpgradeShop(currentState);
+    }
   });
 
   exposeGlobals(engine, marginApi, insiderApi, upgradesApi);

--- a/js/ui/assetDetail.js
+++ b/js/ui/assetDetail.js
@@ -1,0 +1,296 @@
+const escapeHtml = (value) =>
+  String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+const formatMoney = (value) => {
+  const numeric = Number(value) || 0;
+  const absolute = Math.abs(numeric);
+  return `${numeric < 0 ? "-" : ""}$${absolute.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  })}`;
+};
+
+const formatPrice = (price) => {
+  const numeric = Number(price) || 0;
+  const abs = Math.abs(numeric);
+  const digits = abs >= 1000 ? 2 : abs >= 1 ? 2 : 4;
+  return `$${numeric.toLocaleString(undefined, {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits
+  })}`;
+};
+
+const pickTone = (value) => {
+  if (value > 0.0001) return "good";
+  if (value < -0.0001) return "bad";
+  return "neutral";
+};
+
+function buildReason(asset) {
+  if (!asset) {
+    return { text: "Select an asset to inspect market context.", tone: "neutral" };
+  }
+
+  const changePct = Number(asset.changePct) || 0;
+  const tone = pickTone(changePct);
+  const magnitude = Math.abs(changePct);
+  const direction = changePct > 0 ? "up" : changePct < 0 ? "down" : "flat";
+  const base =
+    magnitude < 0.001
+      ? "Price steady on the last tick."
+      : `Price ${direction} ${magnitude.toFixed(2)}% on the last tick.`;
+
+  const meta = asset.lastTickMeta || {};
+  const influences = Array.isArray(meta.influences) ? meta.influences : [];
+  const flags = meta.flags || {};
+
+  let driver = "";
+  if (influences.length) {
+    const strongest = influences.reduce((best, current) => {
+      const currentMag = Math.abs(Number(current?.magnitude) || 0);
+      const bestMag = Math.abs(Number(best?.magnitude) || 0);
+      return currentMag > bestMag ? current : best;
+    }, influences[0]);
+
+    if (strongest) {
+      const driverLabel = strongest.label || strongest.typeLabel || "market flow";
+      const driverTone = pickTone(strongest.magnitude || 0);
+      driver = ` Primary driver: <span class="detail-reason__driver detail-reason__driver--${driverTone}">${escapeHtml(
+        driverLabel
+      )}</span>.`;
+      if (strongest.description) {
+        driver += ` ${escapeHtml(strongest.description)}`;
+      }
+    }
+  }
+
+  const flagMessages = [];
+  if (flags.externalOverride) {
+    flagMessages.push("External shock overrode local order flow.");
+  }
+  if (flags.playerDominant) {
+    flagMessages.push("Your trading flow dominated liquidity.");
+  }
+  if (flags.macroShock) {
+    flagMessages.push("Macro turbulence amplified the move.");
+  } else if (flags.highVolRegime) {
+    flagMessages.push("Elevated volatility regime in effect.");
+  }
+
+  const suffix = flagMessages.length ? ` ${flagMessages.join(" ")}` : "";
+
+  return { text: `${base}${driver}${suffix}`, tone };
+}
+
+function renderEffects(listEl, state, assetId) {
+  if (!listEl) return;
+  const events = Array.isArray(state?.events) ? state.events : [];
+  const relevant = events.filter((event) => event && (event.targetId == null || event.targetId === assetId));
+
+  if (relevant.length === 0) {
+    listEl.innerHTML = '<li class="effect effect--empty">No active timed modifiers.</li>';
+    return;
+  }
+
+  const rows = relevant
+    .map((event) => {
+      const tone = event.kind || "neutral";
+      const expiryBits = [];
+      if (event.expiresOnDay != null) expiryBits.push(`D${event.expiresOnDay}`);
+      if (event.expiresAtTick != null) expiryBits.push(`T${event.expiresAtTick}`);
+      const expiry = expiryBits.length ? expiryBits.join(" · ") : "—";
+
+      const tags = [];
+      if (event.effect?.volMult && event.effect.volMult !== 1) {
+        const cls = event.effect.volMult > 1 ? "bad" : "good";
+        tags.push(`<span class="tag tag--${cls}">Vol ×${event.effect.volMult.toFixed(2)}</span>`);
+      }
+      if (event.effect?.driftShift) {
+        const cls = event.effect.driftShift > 0 ? "good" : "bad";
+        tags.push(`<span class="tag tag--${cls}">Drift ${event.effect.driftShift > 0 ? "+" : ""}${event.effect.driftShift.toFixed(3)}</span>`);
+      }
+      if (Number.isFinite(event.effect?.liquidityShift) && event.effect.liquidityShift !== 0) {
+        const cls = event.effect.liquidityShift > 0 ? "good" : "bad";
+        tags.push(`<span class="tag tag--${cls}">Liq ${event.effect.liquidityShift > 0 ? "+" : ""}${Math.abs(event.effect.liquidityShift).toFixed(2)}</span>`);
+      }
+      if (Number.isFinite(event.effect?.riskShift) && event.effect.riskShift !== 0) {
+        const cls = event.effect.riskShift > 0 ? "bad" : "good";
+        tags.push(`<span class="tag tag--${cls}">Risk ${event.effect.riskShift > 0 ? "+" : ""}${Math.abs(event.effect.riskShift).toFixed(2)}</span>`);
+      }
+
+      return `
+        <li class="effect">
+          <div class="effect__header">
+            <span class="tag tag--${tone}">${escapeHtml(event.kind || "Effect")}</span>
+            <strong>${escapeHtml(event.label || "Scenario")}</strong>
+          </div>
+          <div class="effect__meta">Expires ${escapeHtml(expiry)}</div>
+          <div class="effect__tags">${tags.join(" ")}</div>
+        </li>
+      `;
+    })
+    .join("");
+
+  listEl.innerHTML = rows;
+}
+
+function renderDrivers(listEl, asset) {
+  if (!listEl) return;
+  const meta = asset?.lastTickMeta;
+  if (!meta) {
+    listEl.innerHTML = '<li class="effect effect--empty">No price drivers yet — wait for the next tick.</li>';
+    return;
+  }
+
+  const influences = Array.isArray(meta.influences) ? meta.influences : [];
+  if (influences.length === 0) {
+    listEl.innerHTML = '<li class="effect effect--empty">No major forces moved this asset on the last update.</li>';
+    return;
+  }
+
+  const extras = [];
+  if (meta.flags?.externalOverride) {
+    extras.push('<li class="effect"><div class="effect__meta">External shocks overrode your order flow.</div></li>');
+  }
+  if (meta.flags?.playerDominant) {
+    extras.push('<li class="effect"><div class="effect__meta">Your trading flow is steering the price.</div></li>');
+  }
+  if (meta.flags?.macroShock) {
+    extras.push('<li class="effect"><div class="effect__meta">Macro turbulence is amplifying the move.</div></li>');
+  } else if (meta.flags?.highVolRegime) {
+    extras.push('<li class="effect"><div class="effect__meta">Volatility is running hotter than usual.</div></li>');
+  }
+
+  const rows = influences
+    .map((influence) => {
+      const label = influence.label || influence.typeLabel || "Influence";
+      const typeClass = influence.type ? `tag--${influence.type}` : "tag--neutral";
+      const magnitude = Number(influence.magnitude) || 0;
+      const pct = magnitude * 100;
+      const pctLabel = Math.abs(pct) < 0.001 ? "≈0.00%" : `${pct > 0 ? "+" : ""}${pct.toFixed(2)}%`;
+      const pctTone = pickTone(magnitude);
+      const vol = Number(influence.volMult) || 1;
+      const showVol = Math.abs(vol - 1) > 0.05;
+      const volTag = showVol ? `<span class="tag ${vol > 1 ? "tag--bad" : "tag--good"}">Vol ×${vol.toFixed(2)}</span>` : "";
+      const description = influence.description ? `<div class="effect__meta">${escapeHtml(influence.description)}</div>` : "";
+
+      return `
+        <li class="effect">
+          <div class="effect__header">
+            <span class="tag ${typeClass}">${escapeHtml(influence.typeLabel || influence.type || "Driver")}</span>
+            <strong>${escapeHtml(label)}</strong>
+          </div>
+          ${description}
+          <div class="effect__tags">
+            <span class="tag tag--${pctTone}">${pctLabel}</span>
+            ${volTag}
+          </div>
+        </li>
+      `;
+    })
+    .join("");
+
+  listEl.innerHTML = [...extras, rows].join("");
+}
+
+function drawChart(canvas, history) {
+  if (!canvas || !canvas.getContext) return;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  const series = Array.isArray(history) ? history : [];
+  if (series.length < 2) {
+    return;
+  }
+
+  const width = canvas.width;
+  const height = canvas.height;
+  ctx.fillStyle = "#0d1427";
+  ctx.fillRect(0, 0, width, height);
+  ctx.strokeStyle = "#1f2a47";
+  ctx.strokeRect(0, 0, width, height);
+
+  const min = Math.min(...series);
+  const max = Math.max(...series);
+  const pad = (max - min) * 0.08 || 1;
+  const yMin = min - pad;
+  const yMax = max + pad;
+
+  ctx.beginPath();
+  ctx.lineWidth = 2;
+  ctx.strokeStyle = "#8b5cf6";
+  series.forEach((value, index) => {
+    const x = (index / (series.length - 1)) * (width - 12) + 6;
+    const y = height - ((value - yMin) / (yMax - yMin)) * (height - 12) - 6;
+    if (index === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  });
+  ctx.stroke();
+}
+
+export function createAssetDetailController() {
+  const root = document.querySelector('[data-module="asset-detail"]');
+  if (!root) {
+    return {
+      render() {}
+    };
+  }
+
+  const titleEl = root.querySelector('[data-element="detail-title"]');
+  const assetEl = root.querySelector('[data-element="detail-asset"]');
+  const priceEl = root.querySelector('[data-element="detail-price"]');
+  const positionEl = root.querySelector('[data-element="detail-position"]');
+  const reasonEl = root.querySelector('[data-element="detail-reason"]');
+  const effectsList = root.querySelector('[data-element="effects-list"]');
+  const driversList = root.querySelector('[data-element="drivers-list"]');
+  const chartCanvas = root.querySelector('[data-element="chart"]');
+
+  return {
+    render(state, asset) {
+      if (!asset) {
+        if (titleEl) titleEl.textContent = "Asset Details";
+        if (assetEl) assetEl.textContent = "—";
+        if (priceEl) priceEl.textContent = "—";
+        if (positionEl) positionEl.textContent = "Select an asset to view holdings.";
+        if (reasonEl) {
+          reasonEl.textContent = "Select an asset to inspect market context.";
+          reasonEl.dataset.tone = "neutral";
+        }
+        if (effectsList) effectsList.innerHTML = '<li class="effect effect--empty">No asset selected.</li>';
+        if (driversList) driversList.innerHTML = '<li class="effect effect--empty">No asset selected.</li>';
+        if (chartCanvas) drawChart(chartCanvas, []);
+        return;
+      }
+
+      if (titleEl) titleEl.textContent = `Details — ${asset.id}`;
+      if (assetEl) assetEl.textContent = `${asset.id} · ${asset.name}`;
+      if (priceEl) priceEl.textContent = formatPrice(asset.price);
+
+      if (positionEl) {
+        const position = state?.positions?.[asset.id];
+        if (!position || position.qty <= 0) {
+          positionEl.textContent = "No active position.";
+        } else {
+          const unrl = (asset.price - position.avgCost) * position.qty;
+          const tone = pickTone(unrl);
+          positionEl.innerHTML = `${position.qty} @ ${formatPrice(position.avgCost)} — <span class="pl--${tone}">${formatMoney(unrl)}</span>`;
+        }
+      }
+
+      if (reasonEl) {
+        const reason = buildReason(asset);
+        reasonEl.innerHTML = reason.text;
+        reasonEl.dataset.tone = reason.tone;
+      }
+
+      renderEffects(effectsList, state, asset.id);
+      renderDrivers(driversList, asset);
+      drawChart(chartCanvas, asset.history);
+    }
+  };
+}

--- a/js/ui/eventQueue.js
+++ b/js/ui/eventQueue.js
@@ -1,0 +1,175 @@
+import { EVENT_DEFINITION_MAP } from "../content/events.js";
+
+const escapeHtml = (value) =>
+  String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+const evaluateMaybeFn = (value, payload) => {
+  if (typeof value === "function") {
+    try {
+      return value(payload);
+    } catch (error) {
+      console.error(error);
+      return null;
+    }
+  }
+  return value;
+};
+
+const checkChoiceRequirements = (choice, definition, state, context) => {
+  if (!choice || typeof choice.requirements !== "function") return true;
+  try {
+    return !!choice.requirements({ state, context, choice, definition });
+  } catch (error) {
+    console.error(error);
+    return false;
+  }
+};
+
+const choiceDescription = (choice, definition, state, context) => {
+  if (!choice) return "";
+  const payload = { state, context, choice, definition };
+  const desc = evaluateMaybeFn(choice.description, payload);
+  return typeof desc === "string" ? desc : "";
+};
+
+const choiceDisabledReason = (choice, definition, state, context) => {
+  if (!choice) return "";
+  const payload = { state, context, choice, definition };
+  const reason = evaluateMaybeFn(choice.disabledReason, payload);
+  if (typeof reason === "string" && reason.trim()) return reason;
+  return "Requirements not met.";
+};
+
+const predictChoiceKind = (choice, definition, state, context) => {
+  if (!choice) return definition?.kind ?? "neutral";
+  const payload = { state, context, choice, definition };
+  const outcomeKind = evaluateMaybeFn(choice.outcome?.kind, payload);
+  return (typeof outcomeKind === "string" && outcomeKind) || choice.kind || definition?.kind || "neutral";
+};
+
+const toneClass = (kind) => {
+  if (kind === "good") return "tag--good";
+  if (kind === "bad") return "tag--bad";
+  if (kind === "warn") return "tag--warn";
+  return "tag--neutral";
+};
+
+function renderChoice(choice, definition, pending, state) {
+  const context = pending.context && typeof pending.context === "object" ? pending.context : {};
+  const allowed = checkChoiceRequirements(choice, definition, state, context);
+  const desc = choiceDescription(choice, definition, state, context);
+  const reason = !allowed ? choiceDisabledReason(choice, definition, state, context) : "";
+  const predictedKind = predictChoiceKind(choice, definition, state, context);
+  const className =
+    predictedKind === "good" ? "btn btn-primary" : predictedKind === "bad" ? "btn btn-danger" : "btn";
+  const tooltip = choice.outcome?.text
+    ? ` data-tooltip="${escapeHtml(evaluateMaybeFn(choice.outcome.text, {
+        state,
+        context,
+        choice,
+        definition,
+        pending
+      }) || "" )}"`
+    : "";
+  const choiceId = choice.id != null ? String(choice.id) : "";
+  const instanceId = String(pending.instanceId ?? "");
+
+  return `
+    <li class="event-choice">
+      <button type="button" class="${className}" data-event-choice data-event-id="${escapeHtml(instanceId)}" data-choice-id="${escapeHtml(choiceId)}" ${
+        allowed ? "" : "disabled"
+      }${tooltip}>${escapeHtml(choice.label || "Choose")}</button>
+      <div class="event-choice__body">
+        <p>${desc ? escapeHtml(desc) : "—"}</p>
+        ${!allowed && reason ? `<p class="event-choice__reason">${escapeHtml(reason)}</p>` : ""}
+      </div>
+    </li>
+  `;
+}
+
+function renderCard(pending, state) {
+  if (!pending) return "";
+  const definition = pending.definitionId ? EVENT_DEFINITION_MAP.get(pending.definitionId) : null;
+  const context = pending.context && typeof pending.context === "object" ? pending.context : {};
+  const labelText = pending.label || definition?.label || "Event";
+  const fallbackDescription = definition
+    ? evaluateMaybeFn(definition.description, { state, context, definition })
+    : null;
+  const description = pending.description || (typeof fallbackDescription === "string" ? fallbackDescription : "");
+  const kind = pending.kind || definition?.kind || "neutral";
+  const kindTag = toneClass(kind);
+  const deadlineBits = [];
+  if (Number.isFinite(pending.deadlineDay)) deadlineBits.push(`D${pending.deadlineDay}`);
+  if (Number.isFinite(pending.deadlineTick)) deadlineBits.push(`T${pending.deadlineTick}`);
+  const deadlineLabel = deadlineBits.length ? `Resolve by ${deadlineBits.join(" · ")}` : "No fixed deadline";
+  const assetTag = context.assetId ? `<span class="event-card__asset">${escapeHtml(context.assetId)}</span>` : "";
+  const summary = context.summary || context.reason || context.headline || "";
+  const summaryHtml = summary ? `<div class="event-card__summary">${escapeHtml(summary)}</div>` : "";
+
+  const choices = Array.isArray(definition?.choices) ? definition.choices : [];
+  const renderedChoices = choices.length
+    ? choices.map((choice) => renderChoice(choice, definition, pending, state)).join("")
+    : '<li class="event-choice"><div class="event-choice__body"><p>No actions available.</p></div></li>';
+
+  return `
+    <article class="event-card" data-event-instance="${pending.instanceId}">
+      <header class="event-card__header">
+        <div class="event-card__title">
+          <span class="tag ${kindTag}">${escapeHtml(kind ? kind.charAt(0).toUpperCase() + kind.slice(1) : "Neutral")}</span>
+          <strong>${escapeHtml(labelText)}</strong>
+          ${assetTag}
+        </div>
+        <div class="event-card__deadline">${escapeHtml(deadlineLabel)}</div>
+      </header>
+      ${summaryHtml}
+      <p class="event-card__description">${description ? escapeHtml(description) : "—"}</p>
+      <ul class="event-card__choices">
+        ${renderedChoices}
+      </ul>
+    </article>
+  `;
+}
+
+export function createEventQueueController({ onResolve } = {}) {
+  const root = document.querySelector('[data-module="events"]');
+  if (!root) {
+    return {
+      render() {}
+    };
+  }
+
+  const listEl = root.querySelector('[data-region="event-list"]');
+  const emptyState = root.querySelector('[data-element="events-empty"]');
+
+  if (listEl && typeof onResolve === "function") {
+    listEl.addEventListener("click", (event) => {
+      const button = event.target.closest("[data-event-choice]");
+      if (!button || button.disabled) return;
+      const instanceId = Number(button.getAttribute("data-event-id"));
+      if (!Number.isFinite(instanceId)) return;
+      const choiceId = button.getAttribute("data-choice-id") || null;
+      onResolve(instanceId, choiceId);
+    });
+  }
+
+  return {
+    render(state) {
+      if (!listEl) return;
+      const queue = Array.isArray(state?.pendingEvents) ? state.pendingEvents : [];
+      if (queue.length === 0) {
+        listEl.innerHTML = "";
+        if (emptyState) emptyState.classList.remove("is-hidden");
+        return;
+      }
+
+      const cards = queue.map((pending) => renderCard(pending, state)).filter(Boolean).join("");
+      listEl.innerHTML = cards;
+      if (emptyState) emptyState.classList.add("is-hidden");
+    }
+  };
+}

--- a/js/ui/hud.js
+++ b/js/ui/hud.js
@@ -1,0 +1,63 @@
+const fmtMoney = (value) => {
+  const absolute = Math.abs(Number(value) || 0);
+  return `${value < 0 ? "-" : ""}$${absolute.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  })}`;
+};
+
+function toneForValue(value) {
+  if (value > 0.0001) return "good";
+  if (value < -0.0001) return "bad";
+  return "neutral";
+}
+
+export function createHudController({ onToggleRun, onEndDay, onReset, onOpenMeta } = {}) {
+  const root = document.querySelector('[data-module="hud"]');
+  if (!root) {
+    return {
+      render() {}
+    };
+  }
+
+  const dayEl = root.querySelector('[data-field="day"]');
+  const cashEl = root.querySelector('[data-field="cash"]');
+  const equityEl = root.querySelector('[data-field="equity"]');
+  const plEl = root.querySelector('[data-field="pl"]');
+
+  const toggleBtn = root.querySelector('[data-action="toggle-run"]');
+  const endBtn = root.querySelector('[data-action="end-day"]');
+  const resetBtn = root.querySelector('[data-action="reset-run"]');
+  const metaBtn = root.querySelector('[data-action="open-meta"]');
+
+  if (toggleBtn && typeof onToggleRun === "function") {
+    toggleBtn.addEventListener("click", () => onToggleRun());
+  }
+  if (endBtn && typeof onEndDay === "function") {
+    endBtn.addEventListener("click", () => onEndDay());
+  }
+  if (resetBtn && typeof onReset === "function") {
+    resetBtn.addEventListener("click", () => onReset());
+  }
+  if (metaBtn && typeof onOpenMeta === "function") {
+    metaBtn.addEventListener("click", () => onOpenMeta());
+  }
+
+  return {
+    render({ day = 1, cash = 0, equity = 0, totalPL = 0, unrealized = 0, running = false } = {}) {
+      if (dayEl) dayEl.textContent = String(day);
+      if (cashEl) cashEl.textContent = fmtMoney(cash);
+      if (equityEl) equityEl.textContent = fmtMoney(equity);
+      if (plEl) {
+        const tone = toneForValue(totalPL);
+        const unrl = fmtMoney(unrealized).replace("$", "");
+        plEl.textContent = `${fmtMoney(totalPL)} (${totalPL >= 0 ? "+" : ""}${unrl} unrl)`;
+        plEl.dataset.tone = tone;
+      }
+      if (toggleBtn) {
+        toggleBtn.textContent = running ? "Pause" : "Start";
+        toggleBtn.dataset.state = running ? "running" : "idle";
+      }
+    }
+  };
+}

--- a/js/ui/insiderBanner.js
+++ b/js/ui/insiderBanner.js
@@ -1,5 +1,12 @@
-// js/ui/insiderBanner.js
 import { activeTip } from "../core/insider.js";
+
+const escapeHtml = (value) =>
+  String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 
 export function updateInsiderBanner(state) {
   const el = document.getElementById("insider-banner");
@@ -8,10 +15,14 @@ export function updateInsiderBanner(state) {
   const tip = activeTip(state);
   if (!tip) {
     el.classList.add("hidden");
-    el.textContent = "";
+    el.innerHTML = "";
     return;
   }
   const secs = Math.max(0, Math.ceil((tip.expiresAt - Date.now()) / 1000));
   el.classList.remove("hidden");
-  el.textContent = `Insider Tip: ${tip.assetId} expected to rise. ${secs}s left.`;
+  el.innerHTML = `
+    <span class="insider-banner__label">Insider Wire</span>
+    <span class="insider-banner__body">Bias active on <strong>${escapeHtml(tip.assetId)}</strong>. Ride the drift before it fades.</span>
+    <span class="insider-banner__timer" aria-live="polite">${secs}s</span>
+  `;
 }

--- a/js/ui/marketList.js
+++ b/js/ui/marketList.js
@@ -1,0 +1,149 @@
+const escapeHtml = (value) =>
+  String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+const formatMoney = (value) => {
+  const absolute = Math.abs(Number(value) || 0);
+  return `${value < 0 ? "-" : ""}$${absolute.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  })}`;
+};
+
+const formatPrice = (price) => {
+  const numeric = Number(price) || 0;
+  const abs = Math.abs(numeric);
+  const digits = abs >= 1000 ? 2 : abs >= 1 ? 2 : 4;
+  return `$${numeric.toLocaleString(undefined, {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits
+  })}`;
+};
+
+const pickTone = (value) => {
+  if (value > 0.0001) return "good";
+  if (value < -0.0001) return "bad";
+  return "neutral";
+};
+
+export function createMarketListController({
+  onSelectAsset,
+  onQuickBuy,
+  onQuickSell,
+  onDefaultQtyChange,
+  parseQty
+} = {}) {
+  const root = document.querySelector('[data-module="market"]');
+  if (!root) {
+    return {
+      render() {},
+      setDefaultQty() {}
+    };
+  }
+
+  const tableBody = root.querySelector('[data-region="market-body"]');
+  const emptyState = root.querySelector('[data-element="market-empty"]');
+  const qtyInput = root.querySelector('[data-element="default-qty"]');
+
+  let lastSelectedId = null;
+
+  const coerceQty = (value) => {
+    if (typeof parseQty === "function") return parseQty(value);
+    const numeric = Math.floor(Number(value));
+    return Number.isFinite(numeric) && numeric > 0 ? numeric : 1;
+  };
+
+  if (qtyInput && typeof onDefaultQtyChange === "function") {
+    qtyInput.addEventListener("change", () => {
+      const qty = coerceQty(qtyInput.value);
+      qtyInput.value = String(qty);
+      onDefaultQtyChange(qty);
+    });
+  }
+
+  if (tableBody) {
+    tableBody.addEventListener("click", (event) => {
+      const buyButton = event.target.closest('[data-action="market-buy"]');
+      if (buyButton && typeof onQuickBuy === "function") {
+        const assetId = buyButton.getAttribute("data-id");
+        if (assetId) {
+          const qty = coerceQty(qtyInput ? qtyInput.value : 1);
+          onQuickBuy(assetId, qty);
+        }
+        return;
+      }
+
+      const sellButton = event.target.closest('[data-action="market-sell"]');
+      if (sellButton && typeof onQuickSell === "function") {
+        const assetId = sellButton.getAttribute("data-id");
+        if (assetId) {
+          const qty = coerceQty(qtyInput ? qtyInput.value : 1);
+          onQuickSell(assetId, qty);
+        }
+        return;
+      }
+
+      const row = event.target.closest("tr[data-id]");
+      if (!row) return;
+      const id = row.getAttribute("data-id");
+      if (id && typeof onSelectAsset === "function") {
+        onSelectAsset(id);
+      }
+    });
+  }
+
+  function renderRow(asset, state) {
+    const positions = state.positions || {};
+    const position = positions[asset.id] || { qty: 0, avgCost: 0 };
+    const qty = Number(position.qty) || 0;
+    const avg = Number(position.avgCost) || 0;
+    const unrealized = qty > 0 ? (asset.price - avg) * qty : 0;
+    const change = Number(asset.changePct) || 0;
+    const tone = pickTone(change);
+    const badge = `<span class="badge badge--${tone}">${change >= 0 ? "+" : ""}${change.toFixed(2)}%</span>`;
+    const plTone = pickTone(unrealized);
+
+    return `
+      <tr data-id="${escapeHtml(asset.id)}" ${asset.id === lastSelectedId ? "data-selected=\"true\"" : ""}>
+        <td class="ticker">${escapeHtml(asset.id)}</td>
+        <td class="name">${escapeHtml(asset.name)}</td>
+        <td class="num">${formatPrice(asset.price)}</td>
+        <td class="num">${badge}</td>
+        <td class="num">${qty}</td>
+        <td class="num">${qty === 0 ? "—" : `<span class="pl--${plTone}">${formatMoney(unrealized)}</span>`}</td>
+        <td class="actions">
+          <button class="btn btn-primary" data-action="market-buy" data-id="${escapeHtml(asset.id)}" data-tooltip="Buy ${escapeHtml(asset.id)} using your default quantity">Buy</button>
+          <button class="btn" data-action="market-sell" data-id="${escapeHtml(asset.id)}" data-tooltip="Sell ${escapeHtml(asset.id)} using your default quantity">Sell</button>
+        </td>
+      </tr>
+    `;
+  }
+
+  return {
+    render(state) {
+      if (!tableBody) return;
+      const assets = Array.isArray(state?.assets) ? state.assets : [];
+      lastSelectedId = state?.selected ?? null;
+
+      if (assets.length === 0) {
+        tableBody.innerHTML = "";
+        if (emptyState) emptyState.classList.remove("is-hidden");
+        return;
+      }
+
+      const rows = assets.map((asset) => renderRow(asset, state)).join("");
+      tableBody.innerHTML = rows;
+      if (emptyState) emptyState.classList.add("is-hidden");
+    },
+
+    setDefaultQty(value) {
+      if (!qtyInput) return;
+      const qty = coerceQty(value);
+      qtyInput.value = String(qty);
+    }
+  };
+}

--- a/js/ui/newsFeed.js
+++ b/js/ui/newsFeed.js
@@ -1,0 +1,85 @@
+const escapeHtml = (value) =>
+  String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+const toneClass = (kind) => {
+  if (kind === "good") return "feed__item--good";
+  if (kind === "bad") return "feed__item--bad";
+  if (kind === "warn") return "feed__item--warn";
+  return "feed__item--neutral";
+};
+
+const formatEffectTags = (effect) => {
+  if (!effect) return "";
+  const tags = [];
+  if (Number.isFinite(effect.driftShift) && effect.driftShift !== 0) {
+    const tone = effect.driftShift > 0 ? "good" : "bad";
+    tags.push(`<span class="tag tag--${tone}">Drift ${effect.driftShift > 0 ? "+" : ""}${effect.driftShift.toFixed(3)}</span>`);
+  }
+  if (Number.isFinite(effect.volMult) && effect.volMult !== 1) {
+    const tone = effect.volMult > 1 ? "bad" : "good";
+    tags.push(`<span class="tag tag--${tone}">Vol ×${effect.volMult.toFixed(2)}</span>`);
+  }
+  if (Number.isFinite(effect.liquidityShift) && effect.liquidityShift !== 0) {
+    const tone = effect.liquidityShift > 0 ? "good" : "bad";
+    tags.push(
+      `<span class="tag tag--${tone}">Liq ${effect.liquidityShift > 0 ? "+" : ""}${Math.abs(effect.liquidityShift).toFixed(2)}</span>`
+    );
+  }
+  if (effect.reason) {
+    tags.push(`<span class="tag tag--neutral">${escapeHtml(effect.reason)}</span>`);
+  }
+  return tags.join(" ");
+};
+
+export function createNewsFeedController() {
+  const root = document.querySelector('[data-module="news"]');
+  if (!root) {
+    return {
+      render() {}
+    };
+  }
+
+  const listEl = root.querySelector('[data-region="news-list"]');
+  const emptyState = root.querySelector('[data-element="news-empty"]');
+
+  return {
+    render(feed) {
+      if (!listEl) return;
+      const entries = Array.isArray(feed) ? feed.slice().reverse() : [];
+      if (entries.length === 0) {
+        listEl.innerHTML = "";
+        if (emptyState) emptyState.classList.remove("is-hidden");
+        return;
+      }
+
+      const rows = entries
+        .map((entry) => {
+          const tone = toneClass(entry.kind);
+          const tags = formatEffectTags(entry.effect);
+          const reason = entry.effect?.description || entry.effect?.detail || "";
+          const tooltip = reason ? ` data-tooltip="${escapeHtml(reason)}"` : "";
+          const target = entry.targetId ? `<span class="feed__target">${escapeHtml(entry.targetId)}</span>` : "";
+
+          return `
+            <li class="feed__item ${tone}"${tooltip}>
+              <div class="feed__item-head">
+                <span class="feed__time">${escapeHtml(entry.time || "")}</span>
+                ${target}
+              </div>
+              <div class="feed__text">${escapeHtml(entry.text || "")}</div>
+              ${tags ? `<div class="feed__tags">${tags}</div>` : ""}
+            </li>
+          `;
+        })
+        .join("");
+
+      listEl.innerHTML = rows;
+      if (emptyState) emptyState.classList.add("is-hidden");
+    }
+  };
+}

--- a/js/ui/tradeControls.js
+++ b/js/ui/tradeControls.js
@@ -1,0 +1,90 @@
+const coerceQty = (value, parseQty) => {
+  if (typeof parseQty === "function") return parseQty(value);
+  const numeric = Math.floor(Number(value));
+  return Number.isFinite(numeric) && numeric > 0 ? numeric : 1;
+};
+
+export function createTradeControlsController({ onBuy, onSell, onQtyChange, parseQty } = {}) {
+  const root = document.querySelector('[data-module="trade-controls"]');
+  if (!root) {
+    return {
+      setQty() {},
+      showMessage() {},
+      updateSelection() {}
+    };
+  }
+
+  const qtyInput = root.querySelector('[data-element="trade-qty"]');
+  const buyBtn = root.querySelector('[data-action="trade-buy"]');
+  const sellBtn = root.querySelector('[data-action="trade-sell"]');
+  const messageEl = root.querySelector('[data-element="trade-message"]');
+  const assetLabel = root.querySelector('[data-element="trade-asset"]');
+
+  let lastMessageTimeout = null;
+
+  const readQty = () => coerceQty(qtyInput ? qtyInput.value : 1, parseQty);
+
+  const emitQtyChange = () => {
+    if (typeof onQtyChange === "function" && qtyInput) {
+      const qty = readQty();
+      qtyInput.value = String(qty);
+      onQtyChange(qty);
+    }
+  };
+
+  if (qtyInput) {
+    qtyInput.addEventListener("change", emitQtyChange);
+    qtyInput.addEventListener("blur", emitQtyChange);
+  }
+
+  if (buyBtn && typeof onBuy === "function") {
+    buyBtn.addEventListener("click", () => {
+      const qty = readQty();
+      onBuy(qty);
+    });
+  }
+
+  if (sellBtn && typeof onSell === "function") {
+    sellBtn.addEventListener("click", () => {
+      const qty = readQty();
+      onSell(qty);
+    });
+  }
+
+  const controller = {
+    setQty(value) {
+      if (!qtyInput) return;
+      const qty = coerceQty(value, parseQty);
+      qtyInput.value = String(qty);
+    },
+
+    showMessage(message, tone = "info") {
+      if (!messageEl) return;
+      messageEl.textContent = message || "";
+      messageEl.dataset.tone = tone;
+      messageEl.classList.toggle("is-hidden", !message);
+      clearTimeout(lastMessageTimeout);
+      if (message) {
+        lastMessageTimeout = setTimeout(() => {
+          messageEl.textContent = "";
+          messageEl.dataset.tone = "info";
+          messageEl.classList.add("is-hidden");
+        }, 4200);
+      }
+    },
+
+    updateSelection({ asset, position } = {}) {
+      if (assetLabel) {
+        if (!asset) {
+          assetLabel.textContent = "Select an asset from the market table.";
+        } else {
+          const qty = position?.qty || 0;
+          const suffix = qty > 0 ? ` · Holding ${qty}` : "";
+          assetLabel.textContent = `${asset.id} — ${asset.name}${suffix}`;
+        }
+      }
+    }
+  };
+
+  return controller;
+}

--- a/js/ui/upgrades.js
+++ b/js/ui/upgrades.js
@@ -1,40 +1,130 @@
-// js/ui/upgrades.js
-// Minimal, DOM-only shop UI. Re-renders on state changes.
+import {
+  UPGRADE_DEF,
+  hasUpgrade,
+  canAfford,
+  purchaseUpgrade,
+  ensureUpgradeState
+} from "../core/upgrades.js";
 
-import { UPGRADE_DEF, hasUpgrade, canAfford, purchaseUpgrade } from "../core/upgrades.js";
+const formatMoney = (value) => {
+  const numeric = Number(value) || 0;
+  return `$${numeric.toLocaleString(undefined, { minimumFractionDigits: 0 })}`;
+};
 
-export function renderUpgradeShop(state) {
-  const mount = document.getElementById("upgrades");
-  if (!mount) return;
+let defaultController = null;
 
-  mount.innerHTML = "";
-  Object.values(UPGRADE_DEF).forEach((def) => {
-    const card = document.createElement("div");
-    card.className = "upgrade-card";
-    const owned = hasUpgrade(state, def.id);
-    const disabled = owned || !canAfford(state, def.id);
+export function createUpgradeShopController({
+  root = document.querySelector('[data-module="upgrade-shop"]'),
+  onRequestPurchase,
+  registerGlobal = true
+} = {}) {
+  if (!root) {
+    return {
+      render() {},
+      showStatus() {}
+    };
+  }
 
-    card.innerHTML = `
-      <div class="upgrade-title">${def.name}</div>
-      <div class="upgrade-desc">${def.desc}</div>
-      <div class="upgrade-cta">
-        <span class="price">$${def.price.toLocaleString()}</span>
-        <button class="buy" data-id="${def.id}" ${disabled ? "disabled" : ""}>
-          ${owned ? "Owned" : "Buy"}
-        </button>
-      </div>
-    `;
-    mount.appendChild(card);
-  });
+  const listEl = root.querySelector('[data-region="upgrade-list"]');
+  const statusEl = root.querySelector('[data-element="upgrade-status"]');
+  let latestState = null;
+  let statusTimeout = null;
 
-  mount.onclick = (e) => {
-    const btn = e.target.closest("button.buy");
-    if (!btn) return;
-    const id = btn.getAttribute("data-id");
-    if (purchaseUpgrade(state, id)) {
-      renderUpgradeShop(state);
-      window.dispatchEvent(new CustomEvent("ttm:stateChanged"));
+  const showStatus = (message, tone = "info") => {
+    if (!statusEl) return;
+    statusEl.textContent = message || "";
+    statusEl.dataset.tone = tone;
+    statusEl.classList.toggle("is-hidden", !message);
+    clearTimeout(statusTimeout);
+    if (message) {
+      statusTimeout = setTimeout(() => {
+        statusEl.textContent = "";
+        statusEl.dataset.tone = "info";
+        statusEl.classList.add("is-hidden");
+      }, 4000);
     }
   };
+
+  const requestPurchase = (id) => {
+    if (!id) return { success: false };
+    const handler = typeof onRequestPurchase === "function" ? onRequestPurchase : null;
+    if (handler) {
+      return handler(id, latestState) || { success: false };
+    }
+    if (!latestState) return { success: false };
+    const success = purchaseUpgrade(latestState, id);
+    if (success) {
+      return { success: true, message: `${UPGRADE_DEF[id]?.name || "Upgrade"} unlocked.` };
+    }
+    return { success: false, message: "Unable to purchase upgrade." };
+  };
+
+  if (listEl) {
+    listEl.addEventListener("click", (event) => {
+      const button = event.target.closest("[data-upgrade-id]");
+      if (!button) return;
+      const id = button.getAttribute("data-upgrade-id");
+      const result = requestPurchase(id);
+      if (result?.success) {
+        showStatus(result.message || "Upgrade unlocked.", "good");
+        if (latestState) render(latestState);
+        window.dispatchEvent(new CustomEvent("ttm:upgrades:changed", { detail: { id } }));
+      } else if (result?.message) {
+        showStatus(result.message, "warn");
+      } else {
+        showStatus("Upgrade locked. Earn more cash first.", "warn");
+      }
+    });
+  }
+
+  const render = (state) => {
+    if (!listEl || !state) return;
+    ensureUpgradeState(state);
+    latestState = state;
+    const cards = Object.values(UPGRADE_DEF)
+      .map((def) => {
+        const owned = hasUpgrade(state, def.id);
+        const affordable = canAfford(state, def.id);
+        const disabled = owned || !affordable;
+        const tone = owned ? "owned" : affordable ? "ready" : "locked";
+        const cta = owned ? "Owned" : affordable ? "Buy" : "Insufficient";
+        return `
+          <article class="upgrade-card upgrade-card--${tone}" data-upgrade-card>
+            <div class="upgrade-card__header">
+              <h4>${def.name}</h4>
+              <span class="upgrade-card__price">${formatMoney(def.price)}</span>
+            </div>
+            <p class="upgrade-card__desc">${def.desc}</p>
+            <div class="upgrade-card__actions">
+              <button class="btn ${owned ? "btn-disabled" : "btn-primary"}" data-upgrade-id="${def.id}" ${
+                disabled ? "disabled" : ""
+              }>${cta}</button>
+            </div>
+          </article>
+        `;
+      })
+      .join("");
+
+    listEl.innerHTML = cards || '<div class="upgrade-empty">No upgrades available.</div>';
+  };
+
+  const controller = {
+    render,
+    showStatus
+  };
+
+  if (registerGlobal) {
+    defaultController = controller;
+  }
+
+  return controller;
 }
 
+export function renderUpgradeShop(state) {
+  if (!defaultController) {
+    defaultController = createUpgradeShopController({ registerGlobal: true });
+  }
+  if (defaultController) {
+    defaultController.render(state);
+  }
+}


### PR DESCRIPTION
## Summary
- Rebuild the dashboard markup and design tokens to use a responsive CSS grid layout with room for future meta/tutorial panels.
- Replace ad-hoc DOM code with modular UI controllers (market list, asset detail, trade controls, news feed, event queue, upgrades) and refactor main.js to orchestrate them.
- Add contextual feedback including price-driver summaries, feed effect tags, tooltips, and inline trade confirmations while refreshing the upgrade shop and insider banner styling.

## Testing
- node --check js/main.js js/ui/hud.js js/ui/marketList.js js/ui/assetDetail.js js/ui/tradeControls.js js/ui/newsFeed.js js/ui/eventQueue.js js/ui/upgrades.js js/ui/insiderBanner.js


------
https://chatgpt.com/codex/tasks/task_e_68caf7ecdcf0832a99c9c7617b09f148