### PR TITLE
Add trading day countdown timer and integrate with engine

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -102,6 +102,61 @@ noscript {
   gap: var(--space-3);
 }
 
+.hud__timer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: var(--radius-md);
+  background: linear-gradient(135deg, rgba(21, 30, 56, 0.65), rgba(13, 22, 44, 0.55));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.hud-timer__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.hud-timer__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+}
+
+.hud-timer__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.hud-timer__bar {
+  position: relative;
+  height: 0.45rem;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.hud-timer__progress {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  background: linear-gradient(90deg, rgba(139, 92, 246, 0.85), rgba(59, 130, 246, 0.85));
+  transition: width 160ms linear;
+}
+
+.hud__timer[data-state="paused"] .hud-timer__progress {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.hud__timer[data-state="closing"] .hud-timer__progress {
+  background: linear-gradient(90deg, rgba(245, 158, 11, 0.9), rgba(239, 68, 68, 0.9));
+}
+
 .hud-metric {
   display: flex;
   flex-direction: column;

--- a/index.html
+++ b/index.html
@@ -34,6 +34,15 @@
           <strong class="hud-metric__value hud-metric__value--pl" data-field="pl">$0.00</strong>
         </div>
       </div>
+      <div class="hud__timer" data-field="day-timer" data-state="paused" role="group" aria-label="Trading day countdown">
+        <div class="hud-timer__header">
+          <span class="hud-timer__label">Day Timer</span>
+          <span class="hud-timer__value" data-element="timer-label">Paused</span>
+        </div>
+        <div class="hud-timer__bar" data-element="timer-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="100" aria-valuetext="Market paused">
+          <div class="hud-timer__progress" data-element="timer-progress" style="width: 100%;"></div>
+        </div>
+      </div>
       <div class="hud__actions">
         <button class="btn btn-primary" data-action="toggle-run" data-tooltip="Start or pause the market clock">Start</button>
         <button class="btn" data-action="end-day" data-tooltip="Advance to the next trading day">End Day</button>


### PR DESCRIPTION
## Summary
- add a configurable trading day duration and countdown management to the core game engine, including persistence and restart hooks
- surface remaining day time through the main loop, reschedule after manual and automatic day transitions, and feed countdown data into the HUD
- extend the HUD markup, styles, and rendering logic to display a live day timer progress bar

## Testing
- npm test *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68cb02fe3b58832a9b154d2ea74a160b