### PR TITLE
Add daily briefing overlay and day summary flow

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -931,6 +931,274 @@ canvas[data-element="chart"] {
   }
 }
 
+/* Daily briefing overlay */
+body.has-daily-briefing {
+  overflow: hidden;
+}
+
+.daily-briefing {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-6);
+  background: rgba(4, 8, 20, 0.88);
+  z-index: 12500;
+}
+
+.daily-briefing.is-open {
+  display: flex;
+}
+
+.daily-briefing__dialog {
+  width: min(720px, 95vw);
+  max-height: 92vh;
+  overflow: auto;
+  background: linear-gradient(180deg, rgba(16, 25, 48, 0.97), rgba(9, 14, 30, 0.97));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 1.5rem;
+  box-shadow: var(--shadow-lg);
+  padding: var(--space-6);
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.daily-briefing__close {
+  position: absolute;
+  top: var(--space-3);
+  right: var(--space-3);
+  background: rgba(8, 14, 28, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 50%;
+  width: 2.25rem;
+  height: 2.25rem;
+  color: var(--color-muted);
+  font-size: 1.25rem;
+  line-height: 1;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+}
+
+.daily-briefing__close:hover,
+.daily-briefing__close:focus-visible {
+  color: var(--color-text);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.daily-briefing__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.daily-briefing__eyebrow {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.daily-briefing__header h2 {
+  margin: 0;
+  font-size: 1.6rem;
+}
+
+.daily-briefing__lede {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.daily-briefing__section h3 {
+  margin: 0 0 var(--space-2);
+  font-size: 1rem;
+  letter-spacing: 0.02em;
+}
+
+.daily-briefing__metrics {
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-3);
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.daily-briefing__metric {
+  background: rgba(8, 14, 30, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: var(--radius-lg);
+  padding: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.daily-briefing__metric dt {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+}
+
+.daily-briefing__metric dd {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.daily-briefing__metric strong {
+  font-size: 1.2rem;
+  font-weight: 700;
+}
+
+.daily-briefing__metric-detail {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.daily-briefing__highlights {
+  display: grid;
+  gap: var(--space-3);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.daily-briefing__card {
+  background: rgba(8, 14, 30, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: var(--radius-lg);
+  padding: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.daily-briefing__card h4 {
+  margin: 0;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+}
+
+.daily-briefing__asset-name {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.daily-briefing__asset-change {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.daily-briefing__asset-position,
+.daily-briefing__asset-last {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.daily-briefing__events {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-2);
+}
+
+.daily-briefing__events li {
+  background: rgba(8, 14, 30, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: var(--radius-lg);
+  padding: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.daily-briefing__event-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.daily-briefing__event-text {
+  font-size: 0.95rem;
+}
+
+.daily-briefing__event-meta {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  font-size: 0.8rem;
+  color: var(--color-muted);
+}
+
+.daily-briefing__event-target {
+  font-weight: 600;
+}
+
+.daily-briefing__event-time {
+  font-variant-numeric: tabular-nums;
+}
+
+.daily-briefing__event-kind {
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  border: 1px solid currentColor;
+}
+
+.daily-briefing__event-kind--good {
+  color: var(--color-good);
+}
+
+.daily-briefing__event-kind--bad {
+  color: var(--color-bad);
+}
+
+.daily-briefing__event-kind--warn {
+  color: var(--color-warn);
+}
+
+.daily-briefing__event-kind--note {
+  color: var(--color-info);
+}
+
+.daily-briefing__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+}
+
+.daily-briefing__placeholder {
+  margin: 0;
+  color: var(--color-muted);
+  font-style: italic;
+}
+
+@media (max-width: 640px) {
+  .daily-briefing {
+    padding: var(--space-4);
+  }
+
+  .daily-briefing__dialog {
+    padding: var(--space-5);
+    border-radius: 1.25rem;
+  }
+
+  .daily-briefing__metrics {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  }
+}
+
 /* Meta progression overlay tweaks */
 .meta-layer {
   position: fixed;

--- a/index.html
+++ b/index.html
@@ -186,6 +186,44 @@
     </aside>
   </main>
 
+  <div id="daily-briefing" class="daily-briefing" aria-hidden="true">
+    <div class="daily-briefing__dialog" role="dialog" aria-modal="true" aria-labelledby="daily-briefing-title" tabindex="-1">
+      <button class="daily-briefing__close" type="button" data-action="briefing-dismiss" aria-label="Dismiss daily briefing">×</button>
+      <header class="daily-briefing__header">
+        <p class="daily-briefing__eyebrow">Daily Briefing</p>
+        <h2 id="daily-briefing-title" data-field="title">End of day summary</h2>
+        <p class="daily-briefing__lede" data-field="lede">Daily telemetry will appear here once the market closes.</p>
+      </header>
+      <section class="daily-briefing__section">
+        <h3>Key Metrics</h3>
+        <dl class="daily-briefing__metrics" data-region="metrics"></dl>
+      </section>
+      <section class="daily-briefing__section">
+        <h3>Highlights</h3>
+        <div class="daily-briefing__highlights">
+          <article class="daily-briefing__card" data-region="best">
+            <h4>Top Performer</h4>
+            <p class="daily-briefing__placeholder">Awaiting intel…</p>
+          </article>
+          <article class="daily-briefing__card" data-region="worst">
+            <h4>Lagging Asset</h4>
+            <p class="daily-briefing__placeholder">Awaiting intel…</p>
+          </article>
+        </div>
+      </section>
+      <section class="daily-briefing__section">
+        <h3>Notable Signals</h3>
+        <ul class="daily-briefing__events" data-region="events">
+          <li class="daily-briefing__placeholder">No reports yet.</li>
+        </ul>
+      </section>
+      <footer class="daily-briefing__footer">
+        <button class="btn" type="button" data-action="briefing-dismiss">Dismiss</button>
+        <button class="btn btn-primary" type="button" data-action="briefing-next">Launch Next Day</button>
+      </footer>
+    </div>
+  </div>
+
   <div id="meta-layer" class="meta-layer" aria-hidden="true">
     <div class="meta-dialog" role="dialog" aria-modal="true" aria-labelledby="meta-title">
       <button id="btn-meta-close" class="meta-close" aria-label="Close mission control">×</button>

--- a/js/ui/dailySummary.js
+++ b/js/ui/dailySummary.js
@@ -1,0 +1,401 @@
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+
+const isFiniteNumber = (value) => Number.isFinite(value);
+
+const formatMoney = (value) => {
+  if (!isFiniteNumber(value)) return "—";
+  const prefix = value < 0 ? "-$" : "$";
+  return `${prefix}${Math.abs(value).toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  })}`;
+};
+
+const formatSignedMoney = (value) => {
+  if (!isFiniteNumber(value)) return "—";
+  const base = formatMoney(value);
+  return value > 0 ? `+${base}` : base;
+};
+
+const formatPercent = (value) => {
+  if (!isFiniteNumber(value)) return "—";
+  return `${value.toFixed(2)}%`;
+};
+
+const formatSignedPercent = (value) => {
+  if (!isFiniteNumber(value)) return "—";
+  const base = formatPercent(value);
+  return value > 0 ? `+${base}` : base;
+};
+
+const formatInteger = (value) => {
+  if (!isFiniteNumber(value)) return "—";
+  return Math.round(value).toLocaleString();
+};
+
+const normalizeKind = (kind) => {
+  if (kind === "good" || kind === "bad" || kind === "warn") return kind;
+  return "note";
+};
+
+const kindLabel = (kind) => {
+  if (kind === "good") return "Positive";
+  if (kind === "bad") return "Negative";
+  if (kind === "warn") return "Warning";
+  return "Note";
+};
+
+const getFocusable = (dialog) => {
+  if (!dialog) return [];
+  return Array.from(dialog.querySelectorAll(FOCUSABLE_SELECTOR)).filter((el) => {
+    if (!(el instanceof HTMLElement)) return false;
+    if (el.hasAttribute("disabled")) return false;
+    if (el.getAttribute("aria-hidden") === "true") return false;
+    return true;
+  });
+};
+
+const renderMetrics = (container, summary) => {
+  if (!container) return;
+  container.innerHTML = "";
+  if (!summary) {
+    const placeholder = document.createElement("p");
+    placeholder.className = "daily-briefing__placeholder";
+    placeholder.textContent = "Awaiting telemetry…";
+    container.appendChild(placeholder);
+    return;
+  }
+
+  const metrics = [
+    {
+      label: "Net Worth",
+      value: summary.endNetWorth,
+      formatter: formatMoney,
+      details: [
+        { label: "Δ", value: summary.netChange, formatter: formatSignedMoney },
+        { label: "Start", value: summary.startNetWorth, formatter: formatMoney }
+      ]
+    },
+    {
+      label: "Realized P&L",
+      value: summary.realizedDelta,
+      formatter: formatSignedMoney
+    },
+    {
+      label: "Unrealized P&L",
+      value: summary.unrealizedDelta,
+      formatter: formatSignedMoney
+    },
+    {
+      label: "Cash",
+      value: summary.endCash,
+      formatter: formatMoney,
+      details: [{ label: "Start", value: summary.startCash, formatter: formatMoney }]
+    },
+    {
+      label: "Portfolio Value",
+      value: summary.endPortfolioValue,
+      formatter: formatMoney,
+      details: [
+        { label: "Start", value: summary.startPortfolioValue, formatter: formatMoney }
+      ]
+    },
+    {
+      label: "Trades",
+      value: summary.trades?.total,
+      formatter: formatInteger,
+      details: [
+        { label: "Volume", value: summary.trades?.volume, formatter: formatInteger },
+        { label: "Notional", value: summary.trades?.notional, formatter: formatMoney }
+      ]
+    }
+  ];
+
+  for (const metric of metrics) {
+    const item = document.createElement("div");
+    item.className = "daily-briefing__metric";
+
+    const term = document.createElement("dt");
+    term.textContent = metric.label;
+    item.appendChild(term);
+
+    const def = document.createElement("dd");
+    const primary = document.createElement("strong");
+    primary.textContent = metric.formatter(metric.value);
+    def.appendChild(primary);
+
+    const details = Array.isArray(metric.details) ? metric.details : [];
+    for (const detail of details) {
+      if (!detail || !isFiniteNumber(detail.value)) continue;
+      const span = document.createElement("span");
+      span.className = "daily-briefing__metric-detail";
+      span.textContent = `${detail.label} ${detail.formatter(detail.value)}`;
+      def.appendChild(span);
+    }
+
+    item.appendChild(def);
+    container.appendChild(item);
+  }
+};
+
+const renderAsset = (container, asset, { label, fallback }) => {
+  if (!container) return;
+  container.innerHTML = "";
+
+  const title = document.createElement("h4");
+  title.textContent = label;
+  container.appendChild(title);
+
+  if (!asset) {
+    const placeholder = document.createElement("p");
+    placeholder.className = "daily-briefing__placeholder";
+    placeholder.textContent = fallback;
+    container.appendChild(placeholder);
+    return;
+  }
+
+  const name = document.createElement("div");
+  name.className = "daily-briefing__asset-name";
+  const idPart = asset.id ? `${asset.id}` : "";
+  const namePart = asset.name ? ` — ${asset.name}` : "";
+  name.textContent = `${idPart}${namePart}`;
+  container.appendChild(name);
+
+  const change = document.createElement("div");
+  change.className = "daily-briefing__asset-change";
+  const valueChangeText = formatSignedMoney(asset.valueChange);
+  const pctChangeText = formatSignedPercent(asset.priceChangePct);
+  change.textContent = `${valueChangeText} (${pctChangeText})`;
+  container.appendChild(change);
+
+  const position = document.createElement("div");
+  position.className = "daily-briefing__asset-position";
+  position.textContent = `Position ${formatInteger(asset.startQty)} → ${formatInteger(asset.endQty)}`;
+  container.appendChild(position);
+
+  if (isFiniteNumber(asset.lastTradePrice)) {
+    const last = document.createElement("div");
+    last.className = "daily-briefing__asset-last";
+    const side = asset.lastTradeSide ? asset.lastTradeSide.toUpperCase() : "TRADE";
+    last.textContent = `${side} ${formatMoney(asset.lastTradePrice)}`;
+    container.appendChild(last);
+  }
+};
+
+const renderEvents = (container, events) => {
+  if (!container) return;
+  container.innerHTML = "";
+
+  const items = Array.isArray(events) ? events.slice(0, 6) : [];
+  if (!items.length) {
+    const placeholder = document.createElement("li");
+    placeholder.className = "daily-briefing__placeholder";
+    placeholder.textContent = "No notable signals logged.";
+    container.appendChild(placeholder);
+    return;
+  }
+
+  for (const entry of items) {
+    const item = document.createElement("li");
+    const tone = normalizeKind(entry?.kind);
+
+    const head = document.createElement("div");
+    head.className = "daily-briefing__event-head";
+
+    const badge = document.createElement("span");
+    badge.className = `daily-briefing__event-kind daily-briefing__event-kind--${tone}`;
+    badge.textContent = kindLabel(tone);
+    head.appendChild(badge);
+
+    item.appendChild(head);
+
+    const text = document.createElement("div");
+    text.className = "daily-briefing__event-text";
+    text.textContent = entry?.text || "No description provided.";
+    item.appendChild(text);
+
+    const metaBits = [];
+    if (entry?.time) {
+      const time = document.createElement("span");
+      time.className = "daily-briefing__event-time";
+      time.textContent = entry.time;
+      metaBits.push(time);
+    }
+    if (entry?.targetId) {
+      const target = document.createElement("span");
+      target.className = "daily-briefing__event-target";
+      target.textContent = `Target ${entry.targetId}`;
+      metaBits.push(target);
+    }
+
+    if (metaBits.length) {
+      const meta = document.createElement("div");
+      meta.className = "daily-briefing__event-meta";
+      for (const bit of metaBits) meta.appendChild(bit);
+      item.appendChild(meta);
+    }
+
+    container.appendChild(item);
+  }
+};
+
+export function createDailySummaryController(options = {}) {
+  const root = document.getElementById("daily-briefing");
+  if (!root) {
+    return {
+      show() {},
+      hide() {}
+    };
+  }
+
+  const dialog = root.querySelector(".daily-briefing__dialog");
+  const titleEl = root.querySelector('[data-field="title"]');
+  const ledeEl = root.querySelector('[data-field="lede"]');
+  const metricsRegion = root.querySelector('[data-region="metrics"]');
+  const bestRegion = root.querySelector('[data-region="best"]');
+  const worstRegion = root.querySelector('[data-region="worst"]');
+  const eventsRegion = root.querySelector('[data-region="events"]');
+  const closeButtons = root.querySelectorAll('[data-action="briefing-dismiss"]');
+  const nextButton = root.querySelector('[data-action="briefing-next"]');
+
+  const defaults = {
+    onDismiss: typeof options.onDismiss === "function" ? options.onDismiss : null,
+    onLaunchNextDay: typeof options.onLaunchNextDay === "function" ? options.onLaunchNextDay : null
+  };
+  let callbacks = { ...defaults };
+  let visible = false;
+  let lastFocus = null;
+
+  const setCallbacks = (extra = {}) => {
+    callbacks = {
+      onDismiss: typeof extra.onDismiss === "function" ? extra.onDismiss : defaults.onDismiss,
+      onLaunchNextDay:
+        typeof extra.onLaunchNextDay === "function" ? extra.onLaunchNextDay : defaults.onLaunchNextDay
+    };
+  };
+
+  const focusFirstElement = () => {
+    const focusable = getFocusable(dialog);
+    const target = focusable.find((el) => !el.hasAttribute("data-skip-focus")) || focusable[0] || dialog;
+    if (target && typeof target.focus === "function") {
+      target.focus({ preventScroll: true });
+    }
+  };
+
+  const handleClose = (reason) => {
+    if (!visible) return;
+    hide();
+    const handler =
+      reason === "next"
+        ? callbacks.onLaunchNextDay || callbacks.onDismiss
+        : callbacks.onDismiss || callbacks.onLaunchNextDay;
+    if (typeof handler === "function") {
+      handler(reason);
+    }
+  };
+
+  const handleKeydown = (event) => {
+    if (!visible) return;
+    if (event.key === "Tab") {
+      const focusable = getFocusable(dialog);
+      if (!focusable.length) {
+        event.preventDefault();
+        return;
+      }
+      const currentIndex = focusable.indexOf(document.activeElement);
+      if (event.shiftKey) {
+        if (currentIndex <= 0) {
+          event.preventDefault();
+          focusable[focusable.length - 1].focus();
+        }
+      } else if (currentIndex === focusable.length - 1) {
+        event.preventDefault();
+        focusable[0].focus();
+      }
+    } else if (event.key === "Escape") {
+      event.preventDefault();
+      handleClose("dismiss");
+    }
+  };
+
+  const render = (summary) => {
+    const payload = summary && typeof summary === "object" ? summary : null;
+    if (titleEl) {
+      const dayLabel = isFiniteNumber(payload?.day) ? `Day ${payload.day} Briefing` : "Daily Briefing";
+      titleEl.textContent = dayLabel;
+    }
+    if (ledeEl) {
+      if (!payload) {
+        ledeEl.textContent = "Daily telemetry will appear here once the market closes.";
+      } else {
+        const netChange = isFiniteNumber(payload.netChange) ? payload.netChange : null;
+        const direction =
+          netChange == null ? "settled" : netChange > 0 ? "climbed" : netChange < 0 ? "slid" : "held steady";
+        const netDeltaText = formatSignedMoney(payload.netChange);
+        const endNet = formatMoney(payload.endNetWorth);
+        const realized = formatSignedMoney(payload.realizedDelta);
+        const unrealized = formatSignedMoney(payload.unrealizedDelta);
+        const deltaSuffix = netDeltaText !== "—" ? ` (${netDeltaText})` : "";
+        ledeEl.textContent = `Net worth ${direction} to ${endNet}${deltaSuffix}. Realized ${realized}, unrealized ${unrealized}.`;
+      }
+    }
+
+    renderMetrics(metricsRegion, payload);
+    renderAsset(bestRegion, payload?.bestAsset ?? null, {
+      label: "Top Performer",
+      fallback: "No standout asset logged."
+    });
+    renderAsset(worstRegion, payload?.worstAsset ?? null, {
+      label: "Lagging Asset",
+      fallback: "No losses worth noting."
+    });
+    renderEvents(eventsRegion, payload?.notableEvents ?? []);
+  };
+
+  const show = (summary, extraCallbacks = {}) => {
+    setCallbacks(extraCallbacks);
+    render(summary);
+    visible = true;
+    lastFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    root.classList.add("is-open");
+    root.setAttribute("aria-hidden", "false");
+    document.body.classList.add("has-daily-briefing");
+    requestAnimationFrame(() => {
+      focusFirstElement();
+    });
+  };
+
+  const hide = () => {
+    if (!visible) return;
+    visible = false;
+    root.classList.remove("is-open");
+    root.setAttribute("aria-hidden", "true");
+    document.body.classList.remove("has-daily-briefing");
+    if (lastFocus && typeof lastFocus.focus === "function") {
+      lastFocus.focus({ preventScroll: true });
+    }
+  };
+
+  closeButtons.forEach((btn) => {
+    btn.addEventListener("click", (event) => {
+      event.preventDefault();
+      handleClose("dismiss");
+    });
+  });
+
+  if (nextButton) {
+    nextButton.addEventListener("click", (event) => {
+      event.preventDefault();
+      handleClose("next");
+    });
+  }
+
+  root.addEventListener("keydown", handleKeydown);
+
+  return {
+    show,
+    hide,
+    isOpen: () => visible
+  };
+}


### PR DESCRIPTION
## Summary
- add a dedicated daily briefing overlay container and layout hooks
- implement a UI controller to render the day summary modal with focus management
- refactor day-end handling to pause play, surface the briefing, and resume the next day after dismissal while logging the outcome

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68cb12161878832ab6ff4a46bd03da04