### PR TITLE
Refine command deck layout and add manual day control

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -170,6 +170,7 @@ noscript {
     grid-template-areas:
       "metrics"
       "timer"
+      "options"
       "actions"
       "hint";
   }
@@ -216,6 +217,7 @@ noscript {
   grid-template-columns: repeat(2, minmax(0, 1fr));
   grid-template-areas:
     "metrics timer"
+    "options timer"
     "actions actions"
     "hint hint";
   gap: var(--space-4);
@@ -266,6 +268,95 @@ noscript {
   inset: 0;
   background: radial-gradient(400px 260px at 20% 12%, rgba(245, 158, 11, 0.18), transparent 70%);
   pointer-events: none;
+}
+
+.hud__options {
+  grid-area: options;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  padding: var(--space-4);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: calc(var(--radius-md) * 1.1);
+  background: linear-gradient(145deg, rgba(14, 24, 48, 0.9), rgba(11, 18, 36, 0.82));
+  position: relative;
+  overflow: hidden;
+}
+
+.hud__options::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(320px 220px at 16% 50%, rgba(56, 189, 248, 0.18), transparent 70%);
+  pointer-events: none;
+  opacity: 0.85;
+}
+
+.hud-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-3);
+  cursor: pointer;
+  position: relative;
+  z-index: 1;
+}
+
+.hud-toggle input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.hud-toggle__track {
+  width: 3.5rem;
+  height: 1.75rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  position: relative;
+  transition: background 180ms ease, border-color 180ms ease;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.hud-toggle__track::after {
+  content: "";
+  position: absolute;
+  top: 0.1rem;
+  left: 0.2rem;
+  width: 1.45rem;
+  height: 1.45rem;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(245, 158, 11, 0.92), rgba(56, 189, 248, 0.92));
+  box-shadow: 0 6px 14px rgba(8, 10, 26, 0.45);
+  transition: transform 180ms ease;
+}
+
+.hud-toggle input:checked + .hud-toggle__track {
+  background: rgba(245, 158, 11, 0.25);
+  border-color: rgba(245, 158, 11, 0.6);
+}
+
+.hud-toggle input:checked + .hud-toggle__track::after {
+  transform: translateX(1.7rem);
+}
+
+.hud-toggle__text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.hud-toggle__title {
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.7rem;
+  color: color-mix(in srgb, var(--color-muted) 80%, rgba(255, 255, 255, 0.92));
+}
+
+.hud-toggle__status {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-text);
 }
 
 .hud-timer__header {
@@ -452,13 +543,12 @@ noscript {
   display: grid;
   gap: var(--space-6);
   padding: var(--space-5) var(--space-6) var(--space-6);
-  grid-template-columns: minmax(320px, 1.1fr) minmax(440px, 1.6fr) minmax(320px, 1.1fr);
-  grid-template-rows: minmax(0, 1.05fr) minmax(0, 0.9fr) minmax(0, 0.85fr);
+  grid-template-columns: minmax(360px, 1.05fr) minmax(560px, 1.75fr);
+  grid-template-rows: minmax(0, 1.2fr) minmax(0, 0.8fr);
   grid-auto-rows: minmax(0, 1fr);
   grid-template-areas:
-    "market detail upgrades"
-    "market detail events"
-    "feed detail meta";
+    "market detail"
+    "command detail";
   flex: 1 1 auto;
   min-height: 0;
   height: 100%;
@@ -488,20 +578,15 @@ noscript {
 
 .panel--market { grid-area: market; }
 .panel--detail { grid-area: detail; }
-.panel--events { grid-area: events; }
-.panel--feed { grid-area: feed; }
-.panel--upgrades { grid-area: upgrades; }
-.panel--meta-preview { grid-area: meta; }
+.panel--command { grid-area: command; }
 
 @media (max-width: 1200px) {
   .app-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    grid-template-rows: auto auto auto auto;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    grid-template-rows: minmax(0, 1fr) minmax(0, 0.7fr);
     grid-template-areas:
-      "market market"
-      "detail detail"
-      "events feed"
-      "upgrades meta";
+      "market detail"
+      "command command";
     padding: var(--space-5);
   }
 
@@ -513,14 +598,11 @@ noscript {
 @media (max-width: 840px) {
   .app-grid {
     grid-template-columns: 1fr;
-    grid-template-rows: repeat(6, minmax(0, 1fr));
+    grid-template-rows: repeat(3, minmax(0, 1fr));
     grid-template-areas:
       "market"
       "detail"
-      "events"
-      "feed"
-      "upgrades"
-      "meta";
+      "command";
     padding: var(--space-4);
   }
 
@@ -568,6 +650,249 @@ noscript {
 .panel > * {
   position: relative;
   z-index: 1;
+}
+
+.panel--command {
+  gap: var(--space-5);
+}
+
+.command-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-4);
+}
+
+.command-tile {
+  display: grid;
+  grid-template-columns: auto;
+  gap: 0.35rem;
+  align-content: start;
+  padding: var(--space-4) var(--space-5);
+  border-radius: calc(var(--radius-lg) * 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: linear-gradient(150deg, rgba(12, 20, 38, 0.88), rgba(10, 17, 34, 0.84));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+  transition: transform 150ms ease, box-shadow 150ms ease, border-color 150ms ease;
+}
+
+.command-tile::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(360px 240px at 16% 18%, rgba(245, 158, 11, 0.16), transparent 70%),
+    radial-gradient(320px 320px at 92% 100%, rgba(56, 189, 248, 0.16), transparent 75%);
+  opacity: 0.85;
+  pointer-events: none;
+}
+
+.command-tile:hover,
+.command-tile:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(245, 158, 11, 0.4);
+  box-shadow: 0 18px 32px rgba(8, 12, 30, 0.45);
+  outline: none;
+}
+
+.command-tile:focus-visible {
+  box-shadow: var(--shadow-md), var(--ring);
+}
+
+.command-tile__icon {
+  font-size: 1.4rem;
+  filter: drop-shadow(0 0 12px rgba(245, 158, 11, 0.35));
+}
+
+.command-tile__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.62rem;
+  color: color-mix(in srgb, var(--color-muted) 80%, rgba(56, 189, 248, 0.85));
+}
+
+.command-tile__title {
+  font-size: 1.1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.command-tile__meta {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: color-mix(in srgb, var(--color-muted) 82%, rgba(245, 158, 11, 0.85));
+}
+
+.command-tile__summary {
+  font-size: 0.85rem;
+  color: color-mix(in srgb, var(--color-muted) 85%, rgba(56, 189, 248, 0.82));
+  max-width: 32ch;
+}
+
+.command-tile[data-tone="alert"] {
+  border-color: color-mix(in srgb, var(--color-bad) 60%, rgba(255, 255, 255, 0.12));
+}
+
+.command-tile[data-tone="alert"] .command-tile__meta {
+  color: var(--color-bad);
+}
+
+.module-dock {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-8);
+  background: radial-gradient(960px 720px at 50% 20%, rgba(15, 20, 42, 0.92), rgba(5, 8, 18, 0.94));
+  z-index: 40;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 180ms ease;
+}
+
+.module-dock.is-open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.module-dock__backdrop {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(640px 520px at 50% 30%, rgba(56, 189, 248, 0.12), transparent 70%),
+    rgba(5, 8, 18, 0.72);
+}
+
+.module-dock__panel {
+  position: relative;
+  width: min(960px, 90vw);
+  max-height: min(720px, 90vh);
+  background: linear-gradient(150deg, rgba(12, 20, 38, 0.98), rgba(7, 13, 26, 0.95));
+  border-radius: calc(var(--radius-xl) * 1.1);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 30px 75px rgba(3, 6, 14, 0.7);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  transform: translateY(24px);
+  transition: transform 200ms ease;
+}
+
+.module-dock.is-open .module-dock__panel {
+  transform: translateY(0);
+}
+
+.module-dock__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-5) var(--space-6) var(--space-4);
+  background: linear-gradient(135deg, rgba(245, 158, 11, 0.18), rgba(56, 189, 248, 0.14));
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.module-dock__header h2 {
+  margin: 0;
+  font-size: 1.2rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.module-dock__close {
+  background: none;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 999px;
+  color: inherit;
+  font-size: 1.35rem;
+  line-height: 1;
+  width: 2.1rem;
+  height: 2.1rem;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  transition: border-color 150ms ease, transform 150ms ease;
+}
+
+.module-dock__close:hover,
+.module-dock__close:focus-visible {
+  border-color: rgba(245, 158, 11, 0.8);
+  transform: scale(1.05);
+  outline: none;
+}
+
+.module-dock__body {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: var(--space-5) var(--space-6) var(--space-6);
+  display: grid;
+}
+
+.module-screen {
+  display: none;
+  flex-direction: column;
+  gap: var(--space-4);
+  min-height: 0;
+}
+
+.module-screen.is-active,
+.module-screen[aria-hidden="false"] {
+  display: flex;
+}
+
+.module-screen__header {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  padding-bottom: var(--space-3);
+}
+
+.module-screen__header h3 {
+  margin: 0;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+
+.module-screen__header p {
+  margin: var(--space-2) 0 0;
+  font-size: 0.85rem;
+  color: color-mix(in srgb, var(--color-muted) 82%, rgba(56, 189, 248, 0.8));
+}
+
+body.has-module-dock {
+  overflow: hidden;
+}
+
+@media (max-width: 960px) {
+  .module-dock {
+    padding: var(--space-6);
+  }
+
+  .module-dock__panel {
+    width: min(640px, 94vw);
+  }
+}
+
+@media (max-width: 640px) {
+  .command-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .module-dock {
+    padding: var(--space-4);
+  }
+
+  .module-dock__panel {
+    width: 100%;
+    max-height: 92vh;
+  }
+
+  .module-dock__body {
+    padding: var(--space-4);
+  }
 }
 
 .panel__header {

--- a/index.html
+++ b/index.html
@@ -44,6 +44,16 @@
             <div class="hud-timer__progress" data-element="timer-progress" style="width: 100%;"></div>
           </div>
         </div>
+        <div class="hud__options">
+          <label class="hud-toggle">
+            <input type="checkbox" data-action="toggle-auto-day" />
+            <span class="hud-toggle__track" aria-hidden="true"></span>
+            <span class="hud-toggle__text">
+              <span class="hud-toggle__title">Auto Launch Next Day</span>
+              <span class="hud-toggle__status" data-field="auto-day-status">Manual start</span>
+            </span>
+          </label>
+        </div>
         <div class="hud__actions">
           <button class="btn btn-primary" data-action="toggle-run" data-tooltip="Start or pause the market clock">Start</button>
           <button class="btn" data-action="end-day" data-tooltip="Advance to the next trading day">End Day</button>
@@ -139,53 +149,92 @@
       </div>
     </section>
 
-    <section class="panel panel--events" data-module="events">
+    <section class="panel panel--command" data-module="command-modules">
       <header class="panel__header">
         <div>
-          <h2>Situation Room</h2>
-          <p class="panel__subtitle">Story events with lasting market impact.</p>
+          <h2>Command Modules</h2>
+          <p class="panel__subtitle">Spin up subsystems without losing sight of the market.</p>
         </div>
       </header>
-      <div class="event-queue" data-region="event-list">
-        <div class="event-empty" data-element="events-empty"><span class="meta">No active scenarios.</span></div>
+      <div class="command-grid">
+        <button class="command-tile" type="button" data-module-target="events" data-module-label="Situation Room">
+          <span class="command-tile__icon" aria-hidden="true">🛰️</span>
+          <span class="command-tile__eyebrow">Scenarios</span>
+          <span class="command-tile__title">Situation Room</span>
+          <span class="command-tile__meta" data-field="command-events-count">All clear</span>
+          <span class="command-tile__summary" data-field="command-events-summary">No active scenarios.</span>
+        </button>
+        <button class="command-tile" type="button" data-module-target="news" data-module-label="Market Intel">
+          <span class="command-tile__icon" aria-hidden="true">🛰</span>
+          <span class="command-tile__eyebrow">Signals</span>
+          <span class="command-tile__title">Market Intel</span>
+          <span class="command-tile__meta" data-field="command-news-count">News feed idle</span>
+          <span class="command-tile__summary" data-field="command-news-summary">Waiting for market chatter…</span>
+        </button>
+        <button class="command-tile" type="button" data-module-target="upgrade-shop" data-module-label="Upgrade Hangar">
+          <span class="command-tile__icon" aria-hidden="true">🛠️</span>
+          <span class="command-tile__eyebrow">Upgrades</span>
+          <span class="command-tile__title">Upgrade Hangar</span>
+          <span class="command-tile__meta" data-field="command-upgrade-status">No systems unlocked</span>
+          <span class="command-tile__summary" data-field="command-upgrade-summary">Earn cash to unlock new tech.</span>
+        </button>
+        <button class="command-tile" type="button" data-module-target="meta-preview" data-module-label="Mission Brief">
+          <span class="command-tile__icon" aria-hidden="true">📡</span>
+          <span class="command-tile__eyebrow">Meta</span>
+          <span class="command-tile__title">Mission Brief</span>
+          <span class="command-tile__meta" data-field="command-meta-status">0 research credits</span>
+          <span class="command-tile__summary" data-field="command-meta-summary">Chart long-term upgrades from Mission Control.</span>
+        </button>
       </div>
     </section>
-
-    <section class="panel panel--feed" data-module="news">
-      <header class="panel__header">
-        <div>
-          <h2>News Feed</h2>
-          <p class="panel__subtitle">Events apply temporary market effects. Because vibes move prices.</p>
-        </div>
-      </header>
-      <ul class="feed" data-region="news-list" aria-live="polite"></ul>
-      <div class="feed-empty" data-element="news-empty">Waiting for market chatter…</div>
-    </section>
-
-    <aside class="panel panel--upgrades" data-module="upgrade-shop">
-      <header class="panel__header">
-        <div>
-          <h2>Upgrade Hangar</h2>
-          <p class="panel__subtitle">Invest in tech that rewrites the rules mid-run.</p>
-        </div>
-      </header>
-      <div id="insider-banner" class="insider-banner hidden" role="status" aria-live="polite"></div>
-      <div class="upgrade-status is-hidden" data-element="upgrade-status" aria-live="polite"></div>
-      <div class="upgrade-grid" data-region="upgrade-list"></div>
-    </aside>
-
-    <aside class="panel panel--meta-preview">
-      <header class="panel__header">
-        <div>
-          <h2>Mission Brief</h2>
-          <p class="panel__subtitle">Space reserved for tutorials, goals, or meta progression.</p>
-        </div>
-      </header>
-      <div class="meta-preview">
-        <p>Coming soon: guideposts for your next moonshot. Feature packs can mount here without reworking the dashboard layout.</p>
-      </div>
-    </aside>
     </main>
+  </div>
+
+  <div class="module-dock" data-module-dock aria-hidden="true">
+    <div class="module-dock__backdrop" data-action="close-modules" tabindex="-1"></div>
+    <div class="module-dock__panel" role="dialog" aria-modal="true" aria-labelledby="module-dock-title">
+      <header class="module-dock__header">
+        <h2 id="module-dock-title" data-module-title>Command Module</h2>
+        <button class="module-dock__close" type="button" data-action="close-modules" aria-label="Close module">×</button>
+      </header>
+      <div class="module-dock__body">
+        <section class="module-screen" data-module="events" data-module-screen="events" aria-hidden="true">
+          <header class="module-screen__header">
+            <h3>Situation Room</h3>
+            <p>Story events with lasting market impact.</p>
+          </header>
+          <div class="event-queue" data-region="event-list">
+            <div class="event-empty" data-element="events-empty"><span class="meta">No active scenarios.</span></div>
+          </div>
+        </section>
+        <section class="module-screen" data-module="news" data-module-screen="news" aria-hidden="true">
+          <header class="module-screen__header">
+            <h3>Market Intel</h3>
+            <p>Events apply temporary market effects. Because vibes move prices.</p>
+          </header>
+          <ul class="feed" data-region="news-list" aria-live="polite"></ul>
+          <div class="feed-empty" data-element="news-empty">Waiting for market chatter…</div>
+        </section>
+        <section class="module-screen" data-module="upgrade-shop" data-module-screen="upgrade-shop" aria-hidden="true">
+          <header class="module-screen__header">
+            <h3>Upgrade Hangar</h3>
+            <p>Invest in tech that rewrites the rules mid-run.</p>
+          </header>
+          <div id="insider-banner" class="insider-banner hidden" role="status" aria-live="polite"></div>
+          <div class="upgrade-status is-hidden" data-element="upgrade-status" aria-live="polite"></div>
+          <div class="upgrade-grid" data-region="upgrade-list" data-module-focus></div>
+        </section>
+        <section class="module-screen" data-module="meta-preview" data-module-screen="meta-preview" aria-hidden="true">
+          <header class="module-screen__header">
+            <h3>Mission Brief</h3>
+            <p>Space reserved for tutorials, goals, or meta progression.</p>
+          </header>
+          <div class="meta-preview">
+            <p>Coming soon: guideposts for your next moonshot. Feature packs can mount here without reworking the dashboard layout.</p>
+          </div>
+        </section>
+      </div>
+    </div>
   </div>
 
   <div id="daily-briefing" class="daily-briefing" aria-hidden="true">
@@ -220,7 +269,7 @@
         </ul>
       </section>
       <footer class="daily-briefing__footer">
-        <button class="btn" type="button" data-action="briefing-dismiss">Dismiss</button>
+        <button class="btn" type="button" data-action="briefing-dismiss">Close Briefing</button>
         <button class="btn btn-primary" type="button" data-action="briefing-next">Launch Next Day</button>
       </footer>
     </div>

--- a/js/ui/commandModules.js
+++ b/js/ui/commandModules.js
@@ -1,0 +1,281 @@
+import { UPGRADE_DEF } from "../core/upgrades.js";
+import { META_CURRENCY_SYMBOL } from "../core/metaProgression.js";
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "[tabindex]:not([tabindex='-1'])"
+].join(",");
+
+const formatMoney = (value) => {
+  const amount = Number.isFinite(value) ? value : 0;
+  return `$${amount.toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
+};
+
+const formatCredits = (value) => {
+  const amount = Number.isFinite(value) ? value : 0;
+  return `${amount.toLocaleString()} ${META_CURRENCY_SYMBOL}`.trim();
+};
+
+const getFocusable = (root) => {
+  if (!root) return [];
+  return Array.from(root.querySelectorAll(FOCUSABLE_SELECTOR)).filter((el) =>
+    el.offsetWidth > 0 || el.offsetHeight > 0 || el.getClientRects().length > 0
+  );
+};
+
+const summarizeEvent = (event) => {
+  if (!event) return "No active scenarios.";
+  if (typeof event.label === "string" && event.label.trim()) return event.label;
+  if (typeof event.description === "string" && event.description.trim()) return event.description;
+  return "Scenario awaiting orders.";
+};
+
+const summarizeMeta = (meta) => {
+  if (!meta || typeof meta !== "object") return "Chart long-term upgrades from Mission Control.";
+  if (meta.lastSummary && typeof meta.lastSummary === "object") {
+    const label = meta.lastSummary.label || meta.lastSummary.reason || null;
+    const net = Number.isFinite(meta.lastSummary.netWorth) ? meta.lastSummary.netWorth : null;
+    if (label && net != null) {
+      return `${label} · Net ${formatMoney(net)}`;
+    }
+    if (label) return label;
+  }
+  const runs = Number.isFinite(meta.lifetime?.runs) ? meta.lifetime.runs : 0;
+  if (runs > 0) {
+    const best = Number.isFinite(meta.lifetime?.bestNetWorth) ? meta.lifetime.bestNetWorth : null;
+    return best != null ? `Best run ${formatMoney(best)} · ${runs} logged` : `${runs} runs completed.`;
+  }
+  return "Chart long-term upgrades from Mission Control.";
+};
+
+export function createCommandModulesController() {
+  const root = document.querySelector('[data-module="command-modules"]');
+  const dock = document.querySelector('[data-module-dock]');
+  if (!root || !dock) {
+    return {
+      render() {},
+      open() {},
+      close() {}
+    };
+  }
+
+  const buttons = Array.from(root.querySelectorAll('[data-module-target]'));
+  const buttonMap = new Map(buttons.map((btn) => [btn.getAttribute("data-module-target"), btn]));
+  const labelMap = new Map(buttons.map((btn) => [btn.getAttribute("data-module-target"), btn.getAttribute("data-module-label") || btn.textContent?.trim() || "Module"]));
+
+  const moduleTitle = dock.querySelector('[data-module-title]');
+  const closeTriggers = dock.querySelectorAll('[data-action="close-modules"]');
+  const screens = new Map();
+  dock.querySelectorAll('[data-module-screen]').forEach((pane) => {
+    const id = pane.getAttribute("data-module-screen");
+    if (id) {
+      screens.set(id, pane);
+    }
+  });
+
+  const fields = {
+    eventsCount: root.querySelector('[data-field="command-events-count"]'),
+    eventsSummary: root.querySelector('[data-field="command-events-summary"]'),
+    newsCount: root.querySelector('[data-field="command-news-count"]'),
+    newsSummary: root.querySelector('[data-field="command-news-summary"]'),
+    upgradesStatus: root.querySelector('[data-field="command-upgrade-status"]'),
+    upgradesSummary: root.querySelector('[data-field="command-upgrade-summary"]'),
+    metaStatus: root.querySelector('[data-field="command-meta-status"]'),
+    metaSummary: root.querySelector('[data-field="command-meta-summary"]')
+  };
+
+  let openId = null;
+  let lastFocus = null;
+
+  const focusPane = (pane) => {
+    if (!pane) return;
+    const preferred = pane.querySelector('[data-module-focus]');
+    if (preferred && typeof preferred.focus === "function") {
+      preferred.focus({ preventScroll: true });
+      return;
+    }
+    const focusable = getFocusable(pane);
+    if (focusable.length) {
+      focusable[0].focus({ preventScroll: true });
+    }
+  };
+
+  const setActiveScreen = (id) => {
+    screens.forEach((pane, key) => {
+      const active = key === id;
+      pane.classList.toggle("is-active", active);
+      pane.setAttribute("aria-hidden", active ? "false" : "true");
+    });
+  };
+
+  const open = (id) => {
+    if (!id || !screens.has(id)) return;
+    openId = id;
+    lastFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    setActiveScreen(id);
+    if (moduleTitle) {
+      moduleTitle.textContent = labelMap.get(id) || "Command Module";
+    }
+    dock.classList.add("is-open");
+    dock.setAttribute("aria-hidden", "false");
+    document.body.classList.add("has-module-dock");
+    requestAnimationFrame(() => {
+      focusPane(screens.get(id));
+    });
+  };
+
+  const close = () => {
+    if (!openId) return;
+    openId = null;
+    dock.classList.remove("is-open");
+    dock.setAttribute("aria-hidden", "true");
+    document.body.classList.remove("has-module-dock");
+    if (lastFocus && typeof lastFocus.focus === "function") {
+      lastFocus.focus({ preventScroll: true });
+    }
+  };
+
+  const handleKeydown = (event) => {
+    if (!openId) return;
+    if (event.key === "Escape") {
+      event.preventDefault();
+      close();
+      return;
+    }
+    if (event.key === "Tab") {
+      if (!screens.has(openId)) return;
+      const focusable = getFocusable(dock);
+      if (!focusable.length) {
+        event.preventDefault();
+        return;
+      }
+      const index = focusable.indexOf(document.activeElement);
+      if (event.shiftKey) {
+        if (index <= 0) {
+          event.preventDefault();
+          focusable[focusable.length - 1].focus();
+        }
+      } else if (index === focusable.length - 1) {
+        event.preventDefault();
+        focusable[0].focus();
+      }
+    }
+  };
+
+  buttons.forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const target = btn.getAttribute("data-module-target");
+      open(target);
+    });
+  });
+
+  closeTriggers.forEach((el) => {
+    el.addEventListener("click", (event) => {
+      event.preventDefault();
+      close();
+    });
+  });
+
+  document.addEventListener("keydown", handleKeydown);
+
+  const updateEventsSummary = (state) => {
+    const queue = Array.isArray(state?.pendingEvents) ? state.pendingEvents : [];
+    const count = queue.length;
+    if (fields.eventsCount) {
+      fields.eventsCount.textContent = count ? `${count} active` : "All clear";
+    }
+    if (fields.eventsSummary) {
+      fields.eventsSummary.textContent = summarizeEvent(queue[0]);
+    }
+    const tile = buttonMap.get("events");
+    if (tile) {
+      const alerting = queue.some((item) => item?.kind === "bad" || item?.kind === "warn");
+      if (alerting) {
+        tile.dataset.tone = "alert";
+      } else {
+        delete tile.dataset.tone;
+      }
+    }
+  };
+
+  const updateNewsSummary = (feed) => {
+    const entries = Array.isArray(feed) ? feed : [];
+    const latest = entries.length ? entries[entries.length - 1] : null;
+    if (fields.newsCount) {
+      fields.newsCount.textContent = entries.length ? "Live updates" : "News feed idle";
+    }
+    if (fields.newsSummary) {
+      fields.newsSummary.textContent = latest?.text || "Waiting for market chatter…";
+    }
+    const tile = buttonMap.get("news");
+    if (tile) {
+      const tone = latest?.kind;
+      if (tone === "bad" || tone === "warn") {
+        tile.dataset.tone = "alert";
+      } else {
+        delete tile.dataset.tone;
+      }
+    }
+  };
+
+  const updateUpgradeSummary = (state) => {
+    const tile = buttonMap.get("upgrade-shop");
+    const owned = state?.upgrades?.owned && typeof state.upgrades.owned === "object"
+      ? Object.keys(state.upgrades.owned).length
+      : 0;
+    const total = Object.keys(UPGRADE_DEF).length;
+    if (fields.upgradesStatus) {
+      fields.upgradesStatus.textContent = owned
+        ? `${owned}/${total} systems online`
+        : "No systems unlocked";
+    }
+    const upgrades = Object.values(UPGRADE_DEF);
+    const ownedSet = new Set(Object.keys(state?.upgrades?.owned || {}));
+    const next = upgrades.find((def) => !ownedSet.has(def.id));
+    if (fields.upgradesSummary) {
+      fields.upgradesSummary.textContent = next
+        ? `Next: ${next.name} (${formatMoney(next.price)})`
+        : "All upgrades installed.";
+    }
+    if (tile) {
+      const affordable = upgrades.some((def) => !ownedSet.has(def.id) && state?.cash >= def.price);
+      if (affordable) {
+        tile.dataset.tone = "alert";
+      } else {
+        delete tile.dataset.tone;
+      }
+    }
+  };
+
+  const updateMetaSummary = (meta) => {
+    if (fields.metaStatus) {
+      fields.metaStatus.textContent = formatCredits(meta?.currency);
+    }
+    if (fields.metaSummary) {
+      fields.metaSummary.textContent = summarizeMeta(meta);
+    }
+    const tile = buttonMap.get("meta-preview");
+    if (tile) {
+      if (Number.isFinite(meta?.currency) && meta.currency > 0) {
+        tile.dataset.tone = "alert";
+      } else {
+        delete tile.dataset.tone;
+      }
+    }
+  };
+
+  return {
+    render(state, { feed = [], meta } = {}) {
+      updateEventsSummary(state);
+      updateNewsSummary(feed);
+      updateUpgradeSummary(state);
+      updateMetaSummary(meta);
+    },
+    open,
+    close
+  };
+}

--- a/js/ui/hud.js
+++ b/js/ui/hud.js
@@ -12,7 +12,7 @@ function toneForValue(value) {
   return "neutral";
 }
 
-export function createHudController({ onToggleRun, onEndDay, onReset, onOpenMeta } = {}) {
+export function createHudController({ onToggleRun, onEndDay, onReset, onOpenMeta, onToggleAutoDay } = {}) {
   const root = document.querySelector('[data-module="hud"]');
   if (!root) {
     return {
@@ -28,6 +28,8 @@ export function createHudController({ onToggleRun, onEndDay, onReset, onOpenMeta
   const dayTimerBarEl = dayTimerEl?.querySelector('[data-element="timer-bar"]');
   const dayTimerProgressEl = dayTimerEl?.querySelector('[data-element="timer-progress"]');
   const dayTimerLabelEl = dayTimerEl?.querySelector('[data-element="timer-label"]');
+  const autoToggle = root.querySelector('[data-action="toggle-auto-day"]');
+  const autoStatus = root.querySelector('[data-field="auto-day-status"]');
 
   const toggleBtn = root.querySelector('[data-action="toggle-run"]');
   const endBtn = root.querySelector('[data-action="end-day"]');
@@ -46,6 +48,14 @@ export function createHudController({ onToggleRun, onEndDay, onReset, onOpenMeta
   if (metaBtn && typeof onOpenMeta === "function") {
     metaBtn.addEventListener("click", () => onOpenMeta());
   }
+  if (autoToggle && typeof onToggleAutoDay === "function") {
+    autoToggle.addEventListener("change", () => {
+      onToggleAutoDay(autoToggle.checked);
+      if (autoStatus) {
+        autoStatus.textContent = autoToggle.checked ? "Auto start" : "Manual start";
+      }
+    });
+  }
 
   return {
     render({
@@ -56,7 +66,8 @@ export function createHudController({ onToggleRun, onEndDay, onReset, onOpenMeta
       unrealized = 0,
       running = false,
       dayRemainingMs = null,
-      dayDurationMs = null
+      dayDurationMs = null,
+      autoStartNextDay = false
     } = {}) {
       if (dayEl) dayEl.textContent = String(day);
       if (cashEl) cashEl.textContent = fmtMoney(cash);
@@ -104,6 +115,12 @@ export function createHudController({ onToggleRun, onEndDay, onReset, onOpenMeta
             dayTimerLabelEl.textContent = `${seconds.toFixed(decimals)}s remaining`;
           }
         }
+      }
+      if (autoToggle) {
+        autoToggle.checked = !!autoStartNextDay;
+      }
+      if (autoStatus) {
+        autoStatus.textContent = autoStartNextDay ? "Auto start" : "Manual start";
       }
     }
   };


### PR DESCRIPTION
## Summary
- reorganize the dashboard to introduce a command module panel with tile-based access to events, news, upgrades, and mission brief overlays
- add a command module controller and modal dock to surface subsystem content without cluttering the main grid layout
- introduce an auto-launch day toggle in the HUD and respect the preference when advancing days, giving players time to strategize before the clock runs

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc7864b3a4832a932cfa7010ca790d