### PR TITLE
Improve viewport scaling responsiveness

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -33,6 +33,13 @@
   --radius-lg: 1rem;
   --radius-xl: 1.25rem;
   --ring: 0 0 0 2px color-mix(in srgb, var(--color-accent) 55%, transparent);
+  --ui-scale: 1;
+  --ui-min-scale: 0.6;
+  --ui-max-scale: 2;
+  --ui-offset-top: 0px;
+  --ui-offset-left: 0px;
+  --ui-base-width: 1480px;
+  --ui-base-height: 960px;
 }
 
 * {
@@ -46,7 +53,9 @@ body {
 
 body {
   margin: 0;
-  font: 15px/1.5 var(--font-sans);
+  font-family: var(--font-sans);
+  font-size: calc(15px * clamp(0.85, var(--ui-scale, 1), 1.35));
+  line-height: 1.5;
   background:
     radial-gradient(1600px 960px at 52% -10%, rgba(77, 108, 187, 0.28) 0%, transparent 60%),
     radial-gradient(960px 720px at 12% 115%, rgba(20, 53, 103, 0.35) 0%, transparent 65%),
@@ -97,8 +106,8 @@ noscript {
   grid-template-rows: auto minmax(0, 1fr);
   gap: var(--space-6);
   padding: var(--space-6) var(--space-6) var(--space-7);
-  max-width: 1480px;
-  width: min(100%, 1480px);
+  max-width: var(--ui-base-width, 1480px);
+  width: min(100%, var(--ui-base-width, 1480px));
   margin: 0 auto;
   position: relative;
   min-height: 0;
@@ -115,6 +124,31 @@ noscript {
   opacity: 0.75;
   filter: drop-shadow(0 32px 65px rgba(5, 12, 30, 0.6));
   z-index: -1;
+}
+
+.app-stage {
+  flex: 1 1 auto;
+}
+
+body.is-viewport-scaling .app-stage {
+  position: relative;
+  display: block;
+  flex: 1 1 auto;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
+
+body.is-viewport-scaling .app-frame {
+  position: absolute;
+  top: var(--ui-offset-top, 0px);
+  left: var(--ui-offset-left, 0px);
+  width: var(--ui-base-width, 1480px);
+  min-height: var(--ui-base-height, 960px);
+  transform-origin: top left;
+  transform: scale(var(--ui-scale, 1));
+  will-change: transform;
 }
 
 @media (max-width: 1024px) {

--- a/index.html
+++ b/index.html
@@ -10,295 +10,300 @@
 <body>
   <noscript>This game needs JavaScript. Which, yes, is still a thing in 2025.</noscript>
 
-  <div class="app-shell">
-    <header class="app-header">
-      <div class="app-header__intro">
-        <h1 class="app-header__title">🚀 To The Moon — Trading Sim</h1>
-        <div class="app-header__meta">
-          <p class="app-header__tagline">Prototype command deck. Built for fast iteration and questionable decisions.</p>
-          <div class="hud__timer" data-field="day-timer" data-state="paused" role="group" aria-label="Trading day countdown">
-            <div class="hud-timer__header">
-              <span class="hud-timer__label">Day Timer</span>
-              <span class="hud-timer__value" data-element="timer-label">Paused</span>
+  <div class="app-stage" data-ui-stage>
+    <div class="app-frame" data-ui-frame>
+      <div class="app-shell">
+        <header class="app-header">
+          <div class="app-header__intro">
+            <h1 class="app-header__title">🚀 To The Moon — Trading Sim</h1>
+            <div class="app-header__meta">
+              <p class="app-header__tagline">Prototype command deck. Built for fast iteration and questionable decisions.</p>
+              <div class="hud__timer" data-field="day-timer" data-state="paused" role="group" aria-label="Trading day countdown">
+                <div class="hud-timer__header">
+                  <span class="hud-timer__label">Day Timer</span>
+                  <span class="hud-timer__value" data-element="timer-label">Paused</span>
+                </div>
+                <div class="hud-timer__bar" data-element="timer-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="100" aria-valuetext="Market paused">
+                  <div class="hud-timer__progress" data-element="timer-progress" style="width: 100%;"></div>
+                </div>
+              </div>
             </div>
-            <div class="hud-timer__bar" data-element="timer-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="100" aria-valuetext="Market paused">
-              <div class="hud-timer__progress" data-element="timer-progress" style="width: 100%;"></div>
+          </div>
+          <div class="hud" data-module="hud" role="status" aria-live="polite">
+            <div class="hud__metrics">
+              <div class="hud-metric">
+                <span class="hud-metric__label">Day</span>
+                <strong class="hud-metric__value" data-field="day">1</strong>
+              </div>
+              <div class="hud-metric">
+                <span class="hud-metric__label">Cash</span>
+                <strong class="hud-metric__value" data-field="cash">$10,000.00</strong>
+              </div>
+              <div class="hud-metric">
+                <span class="hud-metric__label">Equity</span>
+                <strong class="hud-metric__value" data-field="equity">$10,000.00</strong>
+              </div>
+              <div class="hud-metric">
+                <span class="hud-metric__label">P&amp;L</span>
+                <strong class="hud-metric__value hud-metric__value--pl" data-field="pl">$0.00</strong>
+              </div>
             </div>
-          </div>
-        </div>
-      </div>
-      <div class="hud" data-module="hud" role="status" aria-live="polite">
-        <div class="hud__metrics">
-          <div class="hud-metric">
-            <span class="hud-metric__label">Day</span>
-            <strong class="hud-metric__value" data-field="day">1</strong>
-          </div>
-          <div class="hud-metric">
-            <span class="hud-metric__label">Cash</span>
-            <strong class="hud-metric__value" data-field="cash">$10,000.00</strong>
-          </div>
-          <div class="hud-metric">
-            <span class="hud-metric__label">Equity</span>
-            <strong class="hud-metric__value" data-field="equity">$10,000.00</strong>
-          </div>
-          <div class="hud-metric">
-            <span class="hud-metric__label">P&amp;L</span>
-            <strong class="hud-metric__value hud-metric__value--pl" data-field="pl">$0.00</strong>
-          </div>
-        </div>
-        <div class="hud__options">
-          <label class="hud-toggle">
-            <input type="checkbox" data-action="toggle-auto-day" />
-            <span class="hud-toggle__track" aria-hidden="true"></span>
-            <span class="hud-toggle__text">
-              <span class="hud-toggle__title">Auto Launch Next Day</span>
-              <span class="hud-toggle__status" data-field="auto-day-status">Manual start</span>
-            </span>
-          </label>
-        </div>
-        <div class="hud__actions">
-          <button class="btn btn-primary" data-action="toggle-run" data-tooltip="Start or pause the market clock">Start</button>
-          <button class="btn" data-action="end-day" data-tooltip="Advance to the next trading day">End Day</button>
-          <button class="btn btn-danger" data-action="reset-run" data-tooltip="Retire this run and cash out">Reset</button>
-          <button class="btn" data-action="open-meta" data-tooltip="Open Mission Control to spend research credits">Mission Control</button>
-        </div>
-        <span class="hud__hint">Autosaves locally. No crypto wallet required. You're welcome.</span>
-      </div>
-    </header>
-
-    <main id="dashboard" class="app-grid">
-      <section class="panel panel--market" data-module="market">
-        <header class="panel__header">
-          <div>
-            <h2>Market Radar</h2>
-            <p class="panel__subtitle">Live tickers, quick actions, and the pulse of chaos.</p>
-          </div>
-          <div class="qty-picker" data-tooltip="Default quantity used for quick trades from the market table">
-            <label for="qty-global">Default Qty</label>
-            <input id="qty-global" data-element="default-qty" type="number" min="1" step="1" value="10" />
+            <div class="hud__options">
+              <label class="hud-toggle">
+                <input type="checkbox" data-action="toggle-auto-day" />
+                <span class="hud-toggle__track" aria-hidden="true"></span>
+                <span class="hud-toggle__text">
+                  <span class="hud-toggle__title">Auto Launch Next Day</span>
+                  <span class="hud-toggle__status" data-field="auto-day-status">Manual start</span>
+                </span>
+              </label>
+            </div>
+            <div class="hud__actions">
+              <button class="btn btn-primary" data-action="toggle-run" data-tooltip="Start or pause the market clock">Start</button>
+              <button class="btn" data-action="end-day" data-tooltip="Advance to the next trading day">End Day</button>
+              <button class="btn btn-danger" data-action="reset-run" data-tooltip="Retire this run and cash out">Reset</button>
+              <button class="btn" data-action="open-meta" data-tooltip="Open Mission Control to spend research credits">Mission Control</button>
+            </div>
+            <span class="hud__hint">Autosaves locally. No crypto wallet required. You're welcome.</span>
           </div>
         </header>
-        <div class="table-wrap">
-          <table class="table" aria-label="Market table">
-            <thead>
-              <tr>
-                <th scope="col">Ticker</th>
-                <th scope="col">Name</th>
-                <th scope="col" class="num">Price</th>
-                <th scope="col">Δ%</th>
-                <th scope="col" class="num">Position</th>
-                <th scope="col" class="num">Unrl. P&amp;L</th>
-              </tr>
-            </thead>
-            <tbody data-region="market-body"></tbody>
-          </table>
-          <div class="table-empty" data-element="market-empty">No assets yet. Launch a run to load the market.</div>
-        </div>
-      </section>
-
-      <section class="panel panel--detail" data-module="asset-detail">
-        <header class="panel__header">
-          <div>
-            <h2 data-element="detail-title">Asset Details</h2>
-            <p class="panel__subtitle">Inspect drivers and positions before you pull the trigger.</p>
-          </div>
-          <div class="detail-reason" data-element="detail-reason" aria-live="polite">Select an asset to inspect market context.</div>
-        </header>
-        <div class="detail-card">
-          <dl class="detail-grid">
-            <div class="detail-line">
-              <dt>Asset</dt>
-              <dd data-element="detail-asset">—</dd>
-            </div>
-            <div class="detail-line">
-              <dt>Price</dt>
-              <dd data-element="detail-price">—</dd>
-            </div>
-            <div class="detail-line">
-              <dt>Your Position</dt>
-              <dd data-element="detail-position">—</dd>
-            </div>
-          </dl>
-
-          <div class="detail-panels">
-            <section class="effects" aria-label="Active effects">
-              <div class="effects__title">Active Effects</div>
-              <ul class="effects__list" data-element="effects-list"></ul>
-            </section>
-
-            <section class="effects effects--drivers" aria-label="Price drivers">
-              <div class="effects__title">Price Drivers</div>
-              <ul class="effects__list" data-element="drivers-list"></ul>
-            </section>
-          </div>
-
-          <canvas data-element="chart" width="560" height="240" aria-label="Price chart"></canvas>
-
-          <section class="trade-shell" data-module="trade-controls">
-            <header class="trade-shell__header">
-              <h3>Trade Controls</h3>
-              <span class="trade-shell__asset" data-element="trade-asset">Select an asset from the market table.</span>
+    
+        <main id="dashboard" class="app-grid">
+          <section class="panel panel--market" data-module="market">
+            <header class="panel__header">
+              <div>
+                <h2>Market Radar</h2>
+                <p class="panel__subtitle">Live tickers, quick actions, and the pulse of chaos.</p>
+              </div>
+              <div class="qty-picker" data-tooltip="Default quantity used for quick trades from the market table">
+                <label for="qty-global">Default Qty</label>
+                <input id="qty-global" data-element="default-qty" type="number" min="1" step="1" value="10" />
+              </div>
             </header>
-            <div class="trade-controls">
-              <label for="trade-qty">Qty</label>
-              <input id="trade-qty" data-element="trade-qty" type="number" min="1" step="1" value="10" />
-              <button class="btn btn-primary" data-action="trade-buy" data-tooltip="Submit a buy order for the selected asset">Buy</button>
-              <button class="btn" data-action="trade-sell" data-tooltip="Submit a sell order for the selected asset">Sell</button>
+            <div class="table-wrap">
+              <table class="table" aria-label="Market table">
+                <thead>
+                  <tr>
+                    <th scope="col">Ticker</th>
+                    <th scope="col">Name</th>
+                    <th scope="col" class="num">Price</th>
+                    <th scope="col">Δ%</th>
+                    <th scope="col" class="num">Position</th>
+                    <th scope="col" class="num">Unrl. P&amp;L</th>
+                  </tr>
+                </thead>
+                <tbody data-region="market-body"></tbody>
+              </table>
+              <div class="table-empty" data-element="market-empty">No assets yet. Launch a run to load the market.</div>
             </div>
-            <div class="trade-confirm is-hidden" data-element="trade-message" role="status" aria-live="polite"></div>
           </section>
-        </div>
-      </section>
-
-      <section class="panel panel--command" data-module="command-modules">
-        <header class="panel__header">
-          <div>
-            <h2>Command Modules</h2>
-            <p class="panel__subtitle">Spin up subsystems without losing sight of the market.</p>
-          </div>
-        </header>
-        <div class="command-grid">
-          <button class="command-tile" type="button" data-module-target="events" data-module-label="Situation Room">
-            <span class="command-tile__icon" aria-hidden="true">🛰️</span>
-            <span class="command-tile__eyebrow">Scenarios</span>
-            <span class="command-tile__title">Situation Room</span>
-            <span class="command-tile__meta" data-field="command-events-count">All clear</span>
-            <span class="command-tile__summary" data-field="command-events-summary">No active scenarios.</span>
-          </button>
-          <button class="command-tile" type="button" data-module-target="news" data-module-label="Market Intel">
-            <span class="command-tile__icon" aria-hidden="true">🛰</span>
-            <span class="command-tile__eyebrow">Signals</span>
-            <span class="command-tile__title">Market Intel</span>
-            <span class="command-tile__meta" data-field="command-news-count">News feed idle</span>
-            <span class="command-tile__summary" data-field="command-news-summary">Waiting for market chatter…</span>
-          </button>
-          <button class="command-tile" type="button" data-module-target="upgrade-shop" data-module-label="Upgrade Hangar">
-            <span class="command-tile__icon" aria-hidden="true">🛠️</span>
-            <span class="command-tile__eyebrow">Upgrades</span>
-            <span class="command-tile__title">Upgrade Hangar</span>
-            <span class="command-tile__meta" data-field="command-upgrade-status">No systems unlocked</span>
-            <span class="command-tile__summary" data-field="command-upgrade-summary">Earn cash to unlock new tech.</span>
-          </button>
-          <button class="command-tile" type="button" data-module-target="meta-preview" data-module-label="Mission Brief">
-            <span class="command-tile__icon" aria-hidden="true">📡</span>
-            <span class="command-tile__eyebrow">Meta</span>
-            <span class="command-tile__title">Mission Brief</span>
-            <span class="command-tile__meta" data-field="command-meta-status">0 research credits</span>
-            <span class="command-tile__summary" data-field="command-meta-summary">Chart long-term upgrades from Mission Control.</span>
-          </button>
-        </div>
-      </section>
-    </main>
-  </div>
-
-  <div class="module-dock" data-module-dock aria-hidden="true">
-    <div class="module-dock__backdrop" data-action="close-modules" tabindex="-1"></div>
-    <div class="module-dock__panel" role="dialog" aria-modal="true" aria-labelledby="module-dock-title">
-      <header class="module-dock__header">
-        <h2 id="module-dock-title" data-module-title>Command Module</h2>
-        <button class="module-dock__close" type="button" data-action="close-modules" aria-label="Close module">×</button>
-      </header>
-      <div class="module-dock__body">
-        <section class="module-screen" data-module="events" data-module-screen="events" aria-hidden="true">
-          <header class="module-screen__header">
-            <h3>Situation Room</h3>
-            <p>Story events with lasting market impact.</p>
-          </header>
-          <div class="event-queue" data-region="event-list">
-            <div class="event-empty" data-element="events-empty"><span class="meta">No active scenarios.</span></div>
-          </div>
-        </section>
-        <section class="module-screen" data-module="news" data-module-screen="news" aria-hidden="true">
-          <header class="module-screen__header">
-            <h3>Market Intel</h3>
-            <p>Events apply temporary market effects. Because vibes move prices.</p>
-          </header>
-          <ul class="feed" data-region="news-list" aria-live="polite"></ul>
-          <div class="feed-empty" data-element="news-empty">Waiting for market chatter…</div>
-        </section>
-        <section class="module-screen" data-module="upgrade-shop" data-module-screen="upgrade-shop" aria-hidden="true">
-          <header class="module-screen__header">
-            <h3>Upgrade Hangar</h3>
-            <p>Invest in tech that rewrites the rules mid-run.</p>
-          </header>
-          <div id="insider-banner" class="insider-banner hidden" role="status" aria-live="polite"></div>
-          <div class="upgrade-status is-hidden" data-element="upgrade-status" aria-live="polite"></div>
-          <div class="upgrade-grid" data-region="upgrade-list" data-module-focus></div>
-        </section>
-        <section class="module-screen" data-module="meta-preview" data-module-screen="meta-preview" aria-hidden="true">
-          <header class="module-screen__header">
-            <h3>Mission Brief</h3>
-            <p>Space reserved for tutorials, goals, or meta progression.</p>
-          </header>
-          <div class="meta-preview">
-            <p>Coming soon: guideposts for your next moonshot. Feature packs can mount here without reworking the dashboard layout.</p>
-          </div>
-        </section>
+    
+          <section class="panel panel--detail" data-module="asset-detail">
+            <header class="panel__header">
+              <div>
+                <h2 data-element="detail-title">Asset Details</h2>
+                <p class="panel__subtitle">Inspect drivers and positions before you pull the trigger.</p>
+              </div>
+          <div class="detail-reason" data-element="detail-reason" aria-live="polite">Select an asset to inspect market context.</div>
+            </header>
+            <div class="detail-card">
+              <dl class="detail-grid">
+                <div class="detail-line">
+                  <dt>Asset</dt>
+                  <dd data-element="detail-asset">—</dd>
+                </div>
+                <div class="detail-line">
+                  <dt>Price</dt>
+                  <dd data-element="detail-price">—</dd>
+                </div>
+                <div class="detail-line">
+                  <dt>Your Position</dt>
+                  <dd data-element="detail-position">—</dd>
+                </div>
+              </dl>
+    
+              <div class="detail-panels">
+                <section class="effects" aria-label="Active effects">
+                  <div class="effects__title">Active Effects</div>
+                  <ul class="effects__list" data-element="effects-list"></ul>
+                </section>
+    
+                <section class="effects effects--drivers" aria-label="Price drivers">
+                  <div class="effects__title">Price Drivers</div>
+                  <ul class="effects__list" data-element="drivers-list"></ul>
+                </section>
+              </div>
+    
+              <canvas data-element="chart" width="560" height="240" aria-label="Price chart"></canvas>
+    
+              <section class="trade-shell" data-module="trade-controls">
+                <header class="trade-shell__header">
+                  <h3>Trade Controls</h3>
+                  <span class="trade-shell__asset" data-element="trade-asset">Select an asset from the market table.</span>
+                </header>
+                <div class="trade-controls">
+                  <label for="trade-qty">Qty</label>
+                  <input id="trade-qty" data-element="trade-qty" type="number" min="1" step="1" value="10" />
+                  <button class="btn btn-primary" data-action="trade-buy" data-tooltip="Submit a buy order for the selected asset">Buy</button>
+                  <button class="btn" data-action="trade-sell" data-tooltip="Submit a sell order for the selected asset">Sell</button>
+                </div>
+                <div class="trade-confirm is-hidden" data-element="trade-message" role="status" aria-live="polite"></div>
+              </section>
+            </div>
+          </section>
+    
+          <section class="panel panel--command" data-module="command-modules">
+            <header class="panel__header">
+              <div>
+                <h2>Command Modules</h2>
+                <p class="panel__subtitle">Spin up subsystems without losing sight of the market.</p>
+              </div>
+            </header>
+            <div class="command-grid">
+              <button class="command-tile" type="button" data-module-target="events" data-module-label="Situation Room">
+                <span class="command-tile__icon" aria-hidden="true">🛰️</span>
+                <span class="command-tile__eyebrow">Scenarios</span>
+                <span class="command-tile__title">Situation Room</span>
+                <span class="command-tile__meta" data-field="command-events-count">All clear</span>
+                <span class="command-tile__summary" data-field="command-events-summary">No active scenarios.</span>
+              </button>
+              <button class="command-tile" type="button" data-module-target="news" data-module-label="Market Intel">
+                <span class="command-tile__icon" aria-hidden="true">🛰</span>
+                <span class="command-tile__eyebrow">Signals</span>
+                <span class="command-tile__title">Market Intel</span>
+                <span class="command-tile__meta" data-field="command-news-count">News feed idle</span>
+                <span class="command-tile__summary" data-field="command-news-summary">Waiting for market chatter…</span>
+              </button>
+              <button class="command-tile" type="button" data-module-target="upgrade-shop" data-module-label="Upgrade Hangar">
+                <span class="command-tile__icon" aria-hidden="true">🛠️</span>
+                <span class="command-tile__eyebrow">Upgrades</span>
+                <span class="command-tile__title">Upgrade Hangar</span>
+                <span class="command-tile__meta" data-field="command-upgrade-status">No systems unlocked</span>
+                <span class="command-tile__summary" data-field="command-upgrade-summary">Earn cash to unlock new tech.</span>
+              </button>
+              <button class="command-tile" type="button" data-module-target="meta-preview" data-module-label="Mission Brief">
+                <span class="command-tile__icon" aria-hidden="true">📡</span>
+                <span class="command-tile__eyebrow">Meta</span>
+                <span class="command-tile__title">Mission Brief</span>
+                <span class="command-tile__meta" data-field="command-meta-status">0 research credits</span>
+                <span class="command-tile__summary" data-field="command-meta-summary">Chart long-term upgrades from Mission Control.</span>
+              </button>
+            </div>
+          </section>
+        </main>
       </div>
-    </div>
-  </div>
 
-  <div id="daily-briefing" class="daily-briefing" aria-hidden="true">
-    <div class="daily-briefing__dialog" role="dialog" aria-modal="true" aria-labelledby="daily-briefing-title" tabindex="-1">
-      <button class="daily-briefing__close" type="button" data-action="briefing-dismiss" aria-label="Dismiss daily briefing">×</button>
-      <header class="daily-briefing__header">
-        <p class="daily-briefing__eyebrow">Daily Briefing</p>
-        <h2 id="daily-briefing-title" data-field="title">End of day summary</h2>
-        <p class="daily-briefing__lede" data-field="lede">Daily telemetry will appear here once the market closes.</p>
-      </header>
-      <section class="daily-briefing__section">
-        <h3>Key Metrics</h3>
-        <dl class="daily-briefing__metrics" data-region="metrics"></dl>
-      </section>
-      <section class="daily-briefing__section">
-        <h3>Highlights</h3>
-        <div class="daily-briefing__highlights">
-          <article class="daily-briefing__card" data-region="best">
-            <h4>Top Performer</h4>
-            <p class="daily-briefing__placeholder">Awaiting intel…</p>
-          </article>
-          <article class="daily-briefing__card" data-region="worst">
-            <h4>Lagging Asset</h4>
-            <p class="daily-briefing__placeholder">Awaiting intel…</p>
-          </article>
+      <div class="module-dock" data-module-dock aria-hidden="true">
+        <div class="module-dock__backdrop" data-action="close-modules" tabindex="-1"></div>
+        <div class="module-dock__panel" role="dialog" aria-modal="true" aria-labelledby="module-dock-title">
+          <header class="module-dock__header">
+            <h2 id="module-dock-title" data-module-title>Command Module</h2>
+            <button class="module-dock__close" type="button" data-action="close-modules" aria-label="Close module">×</button>
+          </header>
+          <div class="module-dock__body">
+            <section class="module-screen" data-module="events" data-module-screen="events" aria-hidden="true">
+              <header class="module-screen__header">
+                <h3>Situation Room</h3>
+                <p>Story events with lasting market impact.</p>
+              </header>
+              <div class="event-queue" data-region="event-list">
+                <div class="event-empty" data-element="events-empty"><span class="meta">No active scenarios.</span></div>
+              </div>
+            </section>
+            <section class="module-screen" data-module="news" data-module-screen="news" aria-hidden="true">
+              <header class="module-screen__header">
+                <h3>Market Intel</h3>
+                <p>Events apply temporary market effects. Because vibes move prices.</p>
+              </header>
+              <ul class="feed" data-region="news-list" aria-live="polite"></ul>
+              <div class="feed-empty" data-element="news-empty">Waiting for market chatter…</div>
+            </section>
+            <section class="module-screen" data-module="upgrade-shop" data-module-screen="upgrade-shop" aria-hidden="true">
+              <header class="module-screen__header">
+                <h3>Upgrade Hangar</h3>
+                <p>Invest in tech that rewrites the rules mid-run.</p>
+              </header>
+              <div id="insider-banner" class="insider-banner hidden" role="status" aria-live="polite"></div>
+              <div class="upgrade-status is-hidden" data-element="upgrade-status" aria-live="polite"></div>
+              <div class="upgrade-grid" data-region="upgrade-list" data-module-focus></div>
+            </section>
+            <section class="module-screen" data-module="meta-preview" data-module-screen="meta-preview" aria-hidden="true">
+              <header class="module-screen__header">
+                <h3>Mission Brief</h3>
+                <p>Space reserved for tutorials, goals, or meta progression.</p>
+              </header>
+              <div class="meta-preview">
+                <p>Coming soon: guideposts for your next moonshot. Feature packs can mount here without reworking the dashboard layout.</p>
+              </div>
+            </section>
+          </div>
         </div>
-      </section>
-      <section class="daily-briefing__section">
-        <h3>Notable Signals</h3>
-        <ul class="daily-briefing__events" data-region="events">
-          <li class="daily-briefing__placeholder">No reports yet.</li>
-        </ul>
-      </section>
-      <footer class="daily-briefing__footer">
-        <button class="btn" type="button" data-action="briefing-dismiss">Close Briefing</button>
-        <button class="btn btn-primary" type="button" data-action="briefing-next">Launch Next Day</button>
+      </div>
+
+      <div id="daily-briefing" class="daily-briefing" aria-hidden="true">
+        <div class="daily-briefing__dialog" role="dialog" aria-modal="true" aria-labelledby="daily-briefing-title" tabindex="-1">
+          <button class="daily-briefing__close" type="button" data-action="briefing-dismiss" aria-label="Dismiss daily briefing">×</button>
+          <header class="daily-briefing__header">
+            <p class="daily-briefing__eyebrow">Daily Briefing</p>
+            <h2 id="daily-briefing-title" data-field="title">End of day summary</h2>
+            <p class="daily-briefing__lede" data-field="lede">Daily telemetry will appear here once the market closes.</p>
+          </header>
+          <section class="daily-briefing__section">
+            <h3>Key Metrics</h3>
+            <dl class="daily-briefing__metrics" data-region="metrics"></dl>
+          </section>
+          <section class="daily-briefing__section">
+            <h3>Highlights</h3>
+            <div class="daily-briefing__highlights">
+              <article class="daily-briefing__card" data-region="best">
+                <h4>Top Performer</h4>
+                <p class="daily-briefing__placeholder">Awaiting intel…</p>
+              </article>
+              <article class="daily-briefing__card" data-region="worst">
+                <h4>Lagging Asset</h4>
+                <p class="daily-briefing__placeholder">Awaiting intel…</p>
+              </article>
+            </div>
+          </section>
+          <section class="daily-briefing__section">
+            <h3>Notable Signals</h3>
+            <ul class="daily-briefing__events" data-region="events">
+              <li class="daily-briefing__placeholder">No reports yet.</li>
+            </ul>
+          </section>
+          <footer class="daily-briefing__footer">
+            <button class="btn" type="button" data-action="briefing-dismiss">Close Briefing</button>
+            <button class="btn btn-primary" type="button" data-action="briefing-next">Launch Next Day</button>
+          </footer>
+        </div>
+      </div>
+
+      <div id="meta-layer" class="meta-layer" aria-hidden="true">
+        <div class="meta-dialog" role="dialog" aria-modal="true" aria-labelledby="meta-title">
+          <button id="btn-meta-close" class="meta-close" aria-label="Close mission control">×</button>
+          <header class="meta-dialog__header">
+            <h2 id="meta-title">Mission Control</h2>
+            <div class="meta-balance">Research Credits: <span id="meta-balance">0</span></div>
+          </header>
+          <div class="meta-dialog__body">
+            <section class="meta-summary" id="meta-summary"></section>
+            <section class="meta-history" id="meta-history"></section>
+            <section class="meta-upgrades" id="meta-upgrades"></section>
+          </div>
+          <footer class="meta-dialog__footer">
+            <button id="btn-meta-start" class="btn btn-primary">Launch New Run</button>
+            <button id="btn-meta-resume" class="btn">Resume Run</button>
+          </footer>
+        </div>
+      </div>
+
+      <footer class="app-footer">
+        <p>Prototype v0.1. Prices are simulated. If you lose money here, that’s on your decision-making, not the physics engine.</p>
       </footer>
     </div>
   </div>
 
-  <div id="meta-layer" class="meta-layer" aria-hidden="true">
-    <div class="meta-dialog" role="dialog" aria-modal="true" aria-labelledby="meta-title">
-      <button id="btn-meta-close" class="meta-close" aria-label="Close mission control">×</button>
-      <header class="meta-dialog__header">
-        <h2 id="meta-title">Mission Control</h2>
-        <div class="meta-balance">Research Credits: <span id="meta-balance">0</span></div>
-      </header>
-      <div class="meta-dialog__body">
-        <section class="meta-summary" id="meta-summary"></section>
-        <section class="meta-history" id="meta-history"></section>
-        <section class="meta-upgrades" id="meta-upgrades"></section>
-      </div>
-      <footer class="meta-dialog__footer">
-        <button id="btn-meta-start" class="btn btn-primary">Launch New Run</button>
-        <button id="btn-meta-resume" class="btn">Resume Run</button>
-      </footer>
-    </div>
-  </div>
-
-  <footer class="app-footer">
-    <p>Prototype v0.1. Prices are simulated. If you lose money here, that’s on your decision-making, not the physics engine.</p>
-  </footer>
-
+  <script type="module" src="./js/ui/viewportScale.js"></script>
   <script type="module" src="./js/main.js"></script>
   <script type="module" src="./js/core/upgrades.js"></script>
   <script type="module" src="./js/core/margin.js"></script>

--- a/index.html
+++ b/index.html
@@ -193,112 +193,112 @@
         </main>
       </div>
 
-      <div class="module-dock" data-module-dock aria-hidden="true">
-        <div class="module-dock__backdrop" data-action="close-modules" tabindex="-1"></div>
-        <div class="module-dock__panel" role="dialog" aria-modal="true" aria-labelledby="module-dock-title">
-          <header class="module-dock__header">
-            <h2 id="module-dock-title" data-module-title>Command Module</h2>
-            <button class="module-dock__close" type="button" data-action="close-modules" aria-label="Close module">×</button>
-          </header>
-          <div class="module-dock__body">
-            <section class="module-screen" data-module="events" data-module-screen="events" aria-hidden="true">
-              <header class="module-screen__header">
-                <h3>Situation Room</h3>
-                <p>Story events with lasting market impact.</p>
-              </header>
-              <div class="event-queue" data-region="event-list">
-                <div class="event-empty" data-element="events-empty"><span class="meta">No active scenarios.</span></div>
-              </div>
-            </section>
-            <section class="module-screen" data-module="news" data-module-screen="news" aria-hidden="true">
-              <header class="module-screen__header">
-                <h3>Market Intel</h3>
-                <p>Events apply temporary market effects. Because vibes move prices.</p>
-              </header>
-              <ul class="feed" data-region="news-list" aria-live="polite"></ul>
-              <div class="feed-empty" data-element="news-empty">Waiting for market chatter…</div>
-            </section>
-            <section class="module-screen" data-module="upgrade-shop" data-module-screen="upgrade-shop" aria-hidden="true">
-              <header class="module-screen__header">
-                <h3>Upgrade Hangar</h3>
-                <p>Invest in tech that rewrites the rules mid-run.</p>
-              </header>
-              <div id="insider-banner" class="insider-banner hidden" role="status" aria-live="polite"></div>
-              <div class="upgrade-status is-hidden" data-element="upgrade-status" aria-live="polite"></div>
-              <div class="upgrade-grid" data-region="upgrade-list" data-module-focus></div>
-            </section>
-            <section class="module-screen" data-module="meta-preview" data-module-screen="meta-preview" aria-hidden="true">
-              <header class="module-screen__header">
-                <h3>Mission Brief</h3>
-                <p>Space reserved for tutorials, goals, or meta progression.</p>
-              </header>
-              <div class="meta-preview">
-                <p>Coming soon: guideposts for your next moonshot. Feature packs can mount here without reworking the dashboard layout.</p>
-              </div>
-            </section>
-          </div>
-        </div>
-      </div>
-
-      <div id="daily-briefing" class="daily-briefing" aria-hidden="true">
-        <div class="daily-briefing__dialog" role="dialog" aria-modal="true" aria-labelledby="daily-briefing-title" tabindex="-1">
-          <button class="daily-briefing__close" type="button" data-action="briefing-dismiss" aria-label="Dismiss daily briefing">×</button>
-          <header class="daily-briefing__header">
-            <p class="daily-briefing__eyebrow">Daily Briefing</p>
-            <h2 id="daily-briefing-title" data-field="title">End of day summary</h2>
-            <p class="daily-briefing__lede" data-field="lede">Daily telemetry will appear here once the market closes.</p>
-          </header>
-          <section class="daily-briefing__section">
-            <h3>Key Metrics</h3>
-            <dl class="daily-briefing__metrics" data-region="metrics"></dl>
-          </section>
-          <section class="daily-briefing__section">
-            <h3>Highlights</h3>
-            <div class="daily-briefing__highlights">
-              <article class="daily-briefing__card" data-region="best">
-                <h4>Top Performer</h4>
-                <p class="daily-briefing__placeholder">Awaiting intel…</p>
-              </article>
-              <article class="daily-briefing__card" data-region="worst">
-                <h4>Lagging Asset</h4>
-                <p class="daily-briefing__placeholder">Awaiting intel…</p>
-              </article>
-            </div>
-          </section>
-          <section class="daily-briefing__section">
-            <h3>Notable Signals</h3>
-            <ul class="daily-briefing__events" data-region="events">
-              <li class="daily-briefing__placeholder">No reports yet.</li>
-            </ul>
-          </section>
-          <footer class="daily-briefing__footer">
-            <button class="btn" type="button" data-action="briefing-dismiss">Close Briefing</button>
-            <button class="btn btn-primary" type="button" data-action="briefing-next">Launch Next Day</button>
-          </footer>
-        </div>
-      </div>
-
-      <div id="meta-layer" class="meta-layer" aria-hidden="true">
-        <div class="meta-dialog" role="dialog" aria-modal="true" aria-labelledby="meta-title">
-          <button id="btn-meta-close" class="meta-close" aria-label="Close mission control">×</button>
-          <header class="meta-dialog__header">
-            <h2 id="meta-title">Mission Control</h2>
-            <div class="meta-balance">Research Credits: <span id="meta-balance">0</span></div>
-          </header>
-          <div class="meta-dialog__body">
-            <section class="meta-summary" id="meta-summary"></section>
-            <section class="meta-history" id="meta-history"></section>
-            <section class="meta-upgrades" id="meta-upgrades"></section>
-          </div>
-          <footer class="meta-dialog__footer">
-            <button id="btn-meta-start" class="btn btn-primary">Launch New Run</button>
-            <button id="btn-meta-resume" class="btn">Resume Run</button>
-          </footer>
-        </div>
-      </div>
-
       <footer class="app-footer">
         <p>Prototype v0.1. Prices are simulated. If you lose money here, that’s on your decision-making, not the physics engine.</p>
+      </footer>
+    </div>
+  </div>
+
+  <div class="module-dock" data-module-dock aria-hidden="true">
+    <div class="module-dock__backdrop" data-action="close-modules" tabindex="-1"></div>
+    <div class="module-dock__panel" role="dialog" aria-modal="true" aria-labelledby="module-dock-title">
+      <header class="module-dock__header">
+        <h2 id="module-dock-title" data-module-title>Command Module</h2>
+        <button class="module-dock__close" type="button" data-action="close-modules" aria-label="Close module">×</button>
+      </header>
+      <div class="module-dock__body">
+        <section class="module-screen" data-module="events" data-module-screen="events" aria-hidden="true">
+          <header class="module-screen__header">
+            <h3>Situation Room</h3>
+            <p>Story events with lasting market impact.</p>
+          </header>
+          <div class="event-queue" data-region="event-list">
+            <div class="event-empty" data-element="events-empty"><span class="meta">No active scenarios.</span></div>
+          </div>
+        </section>
+        <section class="module-screen" data-module="news" data-module-screen="news" aria-hidden="true">
+          <header class="module-screen__header">
+            <h3>Market Intel</h3>
+            <p>Events apply temporary market effects. Because vibes move prices.</p>
+          </header>
+          <ul class="feed" data-region="news-list" aria-live="polite"></ul>
+          <div class="feed-empty" data-element="news-empty">Waiting for market chatter…</div>
+        </section>
+        <section class="module-screen" data-module="upgrade-shop" data-module-screen="upgrade-shop" aria-hidden="true">
+          <header class="module-screen__header">
+            <h3>Upgrade Hangar</h3>
+            <p>Invest in tech that rewrites the rules mid-run.</p>
+          </header>
+          <div id="insider-banner" class="insider-banner hidden" role="status" aria-live="polite"></div>
+          <div class="upgrade-status is-hidden" data-element="upgrade-status" aria-live="polite"></div>
+          <div class="upgrade-grid" data-region="upgrade-list" data-module-focus></div>
+        </section>
+        <section class="module-screen" data-module="meta-preview" data-module-screen="meta-preview" aria-hidden="true">
+          <header class="module-screen__header">
+            <h3>Mission Brief</h3>
+            <p>Space reserved for tutorials, goals, or meta progression.</p>
+          </header>
+          <div class="meta-preview">
+            <p>Coming soon: guideposts for your next moonshot. Feature packs can mount here without reworking the dashboard layout.</p>
+          </div>
+        </section>
+      </div>
+    </div>
+  </div>
+
+  <div id="daily-briefing" class="daily-briefing" aria-hidden="true">
+    <div class="daily-briefing__dialog" role="dialog" aria-modal="true" aria-labelledby="daily-briefing-title" tabindex="-1">
+      <button class="daily-briefing__close" type="button" data-action="briefing-dismiss" aria-label="Dismiss daily briefing">×</button>
+      <header class="daily-briefing__header">
+        <p class="daily-briefing__eyebrow">Daily Briefing</p>
+        <h2 id="daily-briefing-title" data-field="title">End of day summary</h2>
+        <p class="daily-briefing__lede" data-field="lede">Daily telemetry will appear here once the market closes.</p>
+      </header>
+      <section class="daily-briefing__section">
+        <h3>Key Metrics</h3>
+        <dl class="daily-briefing__metrics" data-region="metrics"></dl>
+      </section>
+      <section class="daily-briefing__section">
+        <h3>Highlights</h3>
+        <div class="daily-briefing__highlights">
+          <article class="daily-briefing__card" data-region="best">
+            <h4>Top Performer</h4>
+            <p class="daily-briefing__placeholder">Awaiting intel…</p>
+          </article>
+          <article class="daily-briefing__card" data-region="worst">
+            <h4>Lagging Asset</h4>
+            <p class="daily-briefing__placeholder">Awaiting intel…</p>
+          </article>
+        </div>
+      </section>
+      <section class="daily-briefing__section">
+        <h3>Notable Signals</h3>
+        <ul class="daily-briefing__events" data-region="events">
+          <li class="daily-briefing__placeholder">No reports yet.</li>
+        </ul>
+      </section>
+      <footer class="daily-briefing__footer">
+        <button class="btn" type="button" data-action="briefing-dismiss">Close Briefing</button>
+        <button class="btn btn-primary" type="button" data-action="briefing-next">Launch Next Day</button>
+      </footer>
+    </div>
+  </div>
+
+  <div id="meta-layer" class="meta-layer" aria-hidden="true">
+    <div class="meta-dialog" role="dialog" aria-modal="true" aria-labelledby="meta-title">
+      <button id="btn-meta-close" class="meta-close" aria-label="Close mission control">×</button>
+      <header class="meta-dialog__header">
+        <h2 id="meta-title">Mission Control</h2>
+        <div class="meta-balance">Research Credits: <span id="meta-balance">0</span></div>
+      </header>
+      <div class="meta-dialog__body">
+        <section class="meta-summary" id="meta-summary"></section>
+        <section class="meta-history" id="meta-history"></section>
+        <section class="meta-upgrades" id="meta-upgrades"></section>
+      </div>
+      <footer class="meta-dialog__footer">
+        <button id="btn-meta-start" class="btn btn-primary">Launch New Run</button>
+        <button id="btn-meta-resume" class="btn">Resume Run</button>
       </footer>
     </div>
   </div>

--- a/js/ui/viewportScale.js
+++ b/js/ui/viewportScale.js
@@ -1,0 +1,173 @@
+const STAGE_SELECTOR = "[data-ui-stage]";
+const FRAME_SELECTOR = "[data-ui-frame]";
+const BODY_SCALE_CLASS = "is-viewport-scaling";
+const ROOT_SCALE_VAR = "--ui-scale";
+const SCALE_PRECISION = 4;
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+const toNumber = (value, fallback) => {
+  if (value == null) return fallback;
+  const parsed = Number.parseFloat(typeof value === "string" ? value.trim() : value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+const round = (value, precision = 3) => {
+  if (!Number.isFinite(value)) return 0;
+  const factor = 10 ** precision;
+  return Math.round(value * factor) / factor;
+};
+
+const getViewportBox = () => {
+  const visualViewport = window.visualViewport;
+  if (visualViewport) {
+    return { width: visualViewport.width, height: visualViewport.height };
+  }
+
+  return { width: window.innerWidth, height: window.innerHeight };
+};
+
+function initViewportScaling() {
+  const stage = document.querySelector(STAGE_SELECTOR);
+  const frame = document.querySelector(FRAME_SELECTOR);
+  if (!stage || !frame) {
+    return null;
+  }
+
+  const body = document.body;
+  const root = document.documentElement;
+  const rootStyle = window.getComputedStyle(root);
+  const frameStyle = window.getComputedStyle(frame);
+  const initialRect = frame.getBoundingClientRect();
+
+  const fallbackWidth = toNumber(
+    frameStyle.getPropertyValue("--ui-base-width"),
+    initialRect.width || frame.offsetWidth || 1480
+  );
+  const fallbackHeight = toNumber(
+    frameStyle.getPropertyValue("--ui-base-height"),
+    initialRect.height || frame.offsetHeight || 960
+  );
+
+  const resolvedMinScale = toNumber(
+    frameStyle.getPropertyValue("--ui-min-scale"),
+    toNumber(rootStyle.getPropertyValue("--ui-min-scale"), 0.6)
+  );
+  const resolvedMaxScale = toNumber(
+    frameStyle.getPropertyValue("--ui-max-scale"),
+    toNumber(rootStyle.getPropertyValue("--ui-max-scale"), 2)
+  );
+
+  const minScale = clamp(resolvedMinScale || 0.6, 0.2, 10);
+  const maxScale = Math.max(minScale, resolvedMaxScale || minScale);
+
+  let baseWidth = Math.max(fallbackWidth, round(initialRect.width || fallbackWidth, 1));
+  let baseHeight = Math.max(fallbackHeight, round(initialRect.height || fallbackHeight, 1));
+  let baseSynced = false;
+
+  const setBaseDimensions = (width, height) => {
+    if (!width || !height) return;
+    const normalizedWidth = Math.max(fallbackWidth, round(width, 1));
+    const normalizedHeight = Math.max(fallbackHeight, round(height, 1));
+    if (Math.abs(normalizedWidth - baseWidth) < 1 && Math.abs(normalizedHeight - baseHeight) < 1 && baseSynced) {
+      return;
+    }
+
+    baseWidth = normalizedWidth;
+    baseHeight = normalizedHeight;
+    frame.style.setProperty("--ui-base-width", `${baseWidth}px`);
+    frame.style.setProperty("--ui-base-height", `${baseHeight}px`);
+    baseSynced = true;
+  };
+
+  setBaseDimensions(baseWidth, baseHeight);
+
+  const applyScale = () => {
+    const { width: viewportWidth, height: viewportHeight } = getViewportBox();
+    if (!viewportWidth || !viewportHeight) return;
+
+    let scale = Math.min(viewportWidth / baseWidth, viewportHeight / baseHeight);
+    if (!Number.isFinite(scale) || scale <= 0) {
+      scale = 1;
+    }
+
+    scale = clamp(scale, minScale, maxScale);
+
+    const scaledWidth = baseWidth * scale;
+    const scaledHeight = baseHeight * scale;
+    const offsetLeft = Math.max((viewportWidth - scaledWidth) / 2, 0);
+    const offsetTop = Math.max((viewportHeight - scaledHeight) / 2, 0);
+    const scaleValue = scale.toFixed(SCALE_PRECISION);
+
+    frame.style.setProperty("--ui-scale", scaleValue);
+    frame.style.setProperty("--ui-offset-left", `${round(offsetLeft)}px`);
+    frame.style.setProperty("--ui-offset-top", `${round(offsetTop)}px`);
+    root.style.setProperty(ROOT_SCALE_VAR, scaleValue);
+  };
+
+  const handleResize = () => {
+    applyScale();
+  };
+
+  const observer =
+    typeof ResizeObserver === "function"
+      ? new ResizeObserver((entries) => {
+          for (const entry of entries) {
+            if (entry.target !== frame) continue;
+            const { width, height } = entry.contentRect;
+            if (!width || !height) continue;
+            setBaseDimensions(width, height);
+            applyScale();
+          }
+        })
+      : null;
+
+  observer?.observe(frame);
+
+  const visualViewport = window.visualViewport;
+
+  const activate = () => {
+    body.classList.add(BODY_SCALE_CLASS);
+    applyScale();
+  };
+
+  if (document.readyState === "complete") {
+    requestAnimationFrame(activate);
+  } else if (document.readyState === "interactive") {
+    activate();
+  } else {
+    window.addEventListener("load", activate, { once: true });
+  }
+
+  window.addEventListener("resize", handleResize, { passive: true });
+  window.addEventListener("orientationchange", handleResize, { passive: true });
+  window.addEventListener("fullscreenchange", handleResize);
+  window.addEventListener("pageshow", applyScale);
+  visualViewport?.addEventListener("resize", handleResize, { passive: true });
+  visualViewport?.addEventListener("scroll", handleResize, { passive: true });
+
+  return () => {
+    window.removeEventListener("resize", handleResize);
+    window.removeEventListener("orientationchange", handleResize);
+    window.removeEventListener("fullscreenchange", handleResize);
+    window.removeEventListener("pageshow", applyScale);
+    visualViewport?.removeEventListener("resize", handleResize);
+    visualViewport?.removeEventListener("scroll", handleResize);
+    observer?.disconnect();
+    body.classList.remove(BODY_SCALE_CLASS);
+    frame.style.removeProperty("--ui-scale");
+    frame.style.removeProperty("--ui-offset-left");
+    frame.style.removeProperty("--ui-offset-top");
+    frame.style.removeProperty("--ui-base-width");
+    frame.style.removeProperty("--ui-base-height");
+    root.style.removeProperty(ROOT_SCALE_VAR);
+  };
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", initViewportScaling, { once: true });
+} else {
+  initViewportScaling();
+}
+
+export { initViewportScaling };


### PR DESCRIPTION
## Summary
- extend the UI tokens to cover viewport scaling bounds and let typography and the shell width follow the active scale factor
- overhaul the viewportScale module so the frame can scale above 1x, keeps its baseline measurements in sync, and re-centers after viewport changes
- hook visual viewport and fullscreen events so resizing/orientation shifts continue to fit the command deck without lingering offsets

## Testing
- Not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cd7b1ee3e8832ab55c6c9722d27f91