### PR TITLE
Fix duplicate layout markup and repair viewport scaling

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,159 +67,7 @@
             <span class="hud__hint">Autosaves locally. No crypto wallet required. You're welcome.</span>
           </div>
         </header>
-    
-        <main id="dashboard" class="app-grid">
-          <section class="panel panel--market" data-module="market">
-            <header class="panel__header">
-              <div>
-                <h2>Market Radar</h2>
-                <p class="panel__subtitle">Live tickers, quick actions, and the pulse of chaos.</p>
-              </div>
-              <div class="qty-picker" data-tooltip="Default quantity used for quick trades from the market table">
-                <label for="qty-global">Default Qty</label>
-                <input id="qty-global" data-element="default-qty" type="number" min="1" step="1" value="10" />
-              </div>
-            </header>
-            <div class="table-wrap">
-              <table class="table" aria-label="Market table">
-                <thead>
-                  <tr>
-                    <th scope="col">Ticker</th>
-                    <th scope="col">Name</th>
-                    <th scope="col" class="num">Price</th>
-                    <th scope="col">Δ%</th>
-                    <th scope="col" class="num">Position</th>
-                    <th scope="col" class="num">Unrl. P&amp;L</th>
-                  </tr>
-                </thead>
-                <tbody data-region="market-body"></tbody>
-              </table>
-              <div class="table-empty" data-element="market-empty">No assets yet. Launch a run to load the market.</div>
-            </div>
-          </section>
-    
-          <section class="panel panel--detail" data-module="asset-detail">
-            <header class="panel__header">
-              <div>
-                <h2 data-element="detail-title">Asset Details</h2>
-                <p class="panel__subtitle">Inspect drivers and positions before you pull the trigger.</p>
-              </div>
-          <div class="detail-reason" data-element="detail-reason" aria-live="polite">Select an asset to inspect market context.</div>
-            </header>
-            <div class="detail-card">
-              <dl class="detail-grid">
-                <div class="detail-line">
-                  <dt>Asset</dt>
-                  <dd data-element="detail-asset">—</dd>
-                </div>
-                <div class="detail-line">
-                  <dt>Price</dt>
-                  <dd data-element="detail-price">—</dd>
-                </div>
-                <div class="detail-line">
-                  <dt>Your Position</dt>
-                  <dd data-element="detail-position">—</dd>
-                </div>
-              </dl>
-    
-              <div class="detail-panels">
-                <section class="effects" aria-label="Active effects">
-                  <div class="effects__title">Active Effects</div>
-                  <ul class="effects__list" data-element="effects-list"></ul>
-                </section>
-    
-                <section class="effects effects--drivers" aria-label="Price drivers">
-                  <div class="effects__title">Price Drivers</div>
-                  <ul class="effects__list" data-element="drivers-list"></ul>
-                </section>
-              </div>
-    
-              <canvas data-element="chart" width="560" height="240" aria-label="Price chart"></canvas>
-    
-              <section class="trade-shell" data-module="trade-controls">
-                <header class="trade-shell__header">
-                  <h3>Trade Controls</h3>
-                  <span class="trade-shell__asset" data-element="trade-asset">Select an asset from the market table.</span>
-                </header>
-                <div class="trade-controls">
-                  <label for="trade-qty">Qty</label>
-                  <input id="trade-qty" data-element="trade-qty" type="number" min="1" step="1" value="10" />
-                  <button class="btn btn-primary" data-action="trade-buy" data-tooltip="Submit a buy order for the selected asset">Buy</button>
-                  <button class="btn" data-action="trade-sell" data-tooltip="Submit a sell order for the selected asset">Sell</button>
-                </div>
-                <div class="trade-confirm is-hidden" data-element="trade-message" role="status" aria-live="polite"></div>
-              </section>
-            </div>
-          </section>
-    
-          <section class="panel panel--command" data-module="command-modules">
-            <header class="panel__header">
-              <div>
-                <h2>Command Modules</h2>
-                <p class="panel__subtitle">Spin up subsystems without losing sight of the market.</p>
-              </div>
-            </header>
-            <div class="command-grid">
-              <button class="command-tile" type="button" data-module-target="events" data-module-label="Situation Room">
-                <span class="command-tile__icon" aria-hidden="true">🛰️</span>
-                <span class="command-tile__eyebrow">Scenarios</span>
-                <span class="command-tile__title">Situation Room</span>
-                <span class="command-tile__meta" data-field="command-events-count">All clear</span>
-                <span class="command-tile__summary" data-field="command-events-summary">No active scenarios.</span>
-              </button>
-              <button class="command-tile" type="button" data-module-target="news" data-module-label="Market Intel">
-                <span class="command-tile__icon" aria-hidden="true">🛰</span>
-                <span class="command-tile__eyebrow">Signals</span>
-                <span class="command-tile__title">Market Intel</span>
-                <span class="command-tile__meta" data-field="command-news-count">News feed idle</span>
-                <span class="command-tile__summary" data-field="command-news-summary">Waiting for market chatter…</span>
-              </button>
-              <button class="command-tile" type="button" data-module-target="upgrade-shop" data-module-label="Upgrade Hangar">
-                <span class="command-tile__icon" aria-hidden="true">🛠️</span>
-                <span class="command-tile__eyebrow">Upgrades</span>
-                <span class="command-tile__title">Upgrade Hangar</span>
-                <span class="command-tile__meta" data-field="command-upgrade-status">No systems unlocked</span>
-                <span class="command-tile__summary" data-field="command-upgrade-summary">Earn cash to unlock new tech.</span>
-              </button>
-              <button class="command-tile" type="button" data-module-target="meta-preview" data-module-label="Mission Brief">
-                <span class="command-tile__icon" aria-hidden="true">📡</span>
-                <span class="command-tile__eyebrow">Meta</span>
-                <span class="command-tile__title">Mission Brief</span>
-                <span class="command-tile__meta" data-field="command-meta-status">0 research credits</span>
-                <span class="command-tile__summary" data-field="command-meta-summary">Chart long-term upgrades from Mission Control.</span>
-              </button>
-            </div>
-          </section>
-        </main>
-      </div>
 
-      <footer class="app-footer">
-        <p>Prototype v0.1. Prices are simulated. If you lose money here, that’s on your decision-making, not the physics engine.</p>
-      </footer>
-    </div>
-  </div>
-=======
-            </div>
-            <div class="hud__options">
-              <label class="hud-toggle">
-                <input type="checkbox" data-action="toggle-auto-day" />
-                <span class="hud-toggle__track" aria-hidden="true"></span>
-                <span class="hud-toggle__text">
-                  <span class="hud-toggle__title">Auto Launch Next Day</span>
-                  <span class="hud-toggle__status" data-field="auto-day-status">Manual start</span>
-                </span>
-              </label>
-            </div>
-            <div class="hud__actions">
-              <button class="btn btn-primary" data-action="toggle-run" data-tooltip="Start or pause the market clock">Start</button>
-              <button class="btn" data-action="end-day" data-tooltip="Advance to the next trading day">End Day</button>
-              <button class="btn btn-danger" data-action="reset-run" data-tooltip="Retire this run and cash out">Reset</button>
-              <button class="btn" data-action="open-meta" data-tooltip="Open Mission Control to spend research credits">Mission Control</button>
-            </div>
-            <span class="hud__hint">Autosaves locally. No crypto wallet required. You're welcome.</span>
-          </div>
-        </header>
-    
         <main id="dashboard" class="app-grid">
           <section class="panel panel--market" data-module="market">
             <header class="panel__header">
@@ -249,14 +97,14 @@
               <div class="table-empty" data-element="market-empty">No assets yet. Launch a run to load the market.</div>
             </div>
           </section>
-    
+
           <section class="panel panel--detail" data-module="asset-detail">
             <header class="panel__header">
               <div>
                 <h2 data-element="detail-title">Asset Details</h2>
                 <p class="panel__subtitle">Inspect drivers and positions before you pull the trigger.</p>
               </div>
-          <div class="detail-reason" data-element="detail-reason" aria-live="polite">Select an asset to inspect market context.</div>
+              <div class="detail-reason" data-element="detail-reason" aria-live="polite">Select an asset to inspect market context.</div>
             </header>
             <div class="detail-card">
               <dl class="detail-grid">
@@ -273,21 +121,21 @@
                   <dd data-element="detail-position">—</dd>
                 </div>
               </dl>
-    
+
               <div class="detail-panels">
                 <section class="effects" aria-label="Active effects">
                   <div class="effects__title">Active Effects</div>
                   <ul class="effects__list" data-element="effects-list"></ul>
                 </section>
-    
+
                 <section class="effects effects--drivers" aria-label="Price drivers">
                   <div class="effects__title">Price Drivers</div>
                   <ul class="effects__list" data-element="drivers-list"></ul>
                 </section>
               </div>
-    
+
               <canvas data-element="chart" width="560" height="240" aria-label="Price chart"></canvas>
-    
+
               <section class="trade-shell" data-module="trade-controls">
                 <header class="trade-shell__header">
                   <h3>Trade Controls</h3>
@@ -303,7 +151,7 @@
               </section>
             </div>
           </section>
-    
+
           <section class="panel panel--command" data-module="command-modules">
             <header class="panel__header">
               <div>


### PR DESCRIPTION
## Summary
- remove the duplicated dashboard markup so the HUD and command modules render once
- keep the docked overlays (modules, briefing, mission control) wired after the cleanup
- rebuild the viewport scaling utility to clamp scale and respond to resize/viewport events reliably

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdabd93b2c832aaf1920c1d93c0ba7