### PR TITLE
Add Operations contract system and Operations Board module for V1 command‑deck

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2357,3 +2357,105 @@ body.has-daily-briefing {
 .meta-stats li strong {
   color: var(--color-text);
 }
+
+.operations-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
+}
+
+.operations-pill {
+  border: 1px solid color-mix(in srgb, var(--color-highlight) 34%, transparent);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2) var(--space-3);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+  background: linear-gradient(135deg, rgba(11, 19, 39, 0.92), rgba(13, 24, 45, 0.86));
+}
+
+.operations-pill strong {
+  display: block;
+  font-size: 1rem;
+  margin-top: 0.2rem;
+  color: var(--color-text);
+}
+
+.operations-list {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.operations-empty {
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  border-radius: var(--radius-sm);
+  padding: var(--space-4);
+  color: var(--color-muted);
+}
+
+.operation-card {
+  border: 1px solid rgba(56, 189, 248, 0.2);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+  background: linear-gradient(145deg, rgba(14, 23, 44, 0.96), rgba(9, 16, 31, 0.9));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.025);
+}
+
+.operation-card--claimable {
+  border-color: rgba(245, 158, 11, 0.5);
+  box-shadow: 0 0 0 1px rgba(245, 158, 11, 0.25), 0 12px 24px rgba(245, 158, 11, 0.12);
+}
+
+.operation-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.operation-card__header h4 {
+  margin: 0.2rem 0 0;
+}
+
+.operation-card__eyebrow {
+  margin: 0;
+  color: var(--color-highlight);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+}
+
+.operation-card__reward {
+  font-size: 0.82rem;
+  color: var(--color-accent);
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.operation-card__progress {
+  display: flex;
+  justify-content: space-between;
+  margin-top: var(--space-3);
+  font-size: 0.78rem;
+  color: var(--color-muted);
+}
+
+.operation-card__bar {
+  margin-top: var(--space-2);
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.2);
+  overflow: hidden;
+}
+
+.operation-card__bar span {
+  display: block;
+  height: 100%;
+  background: linear-gradient(90deg, var(--color-highlight), color-mix(in srgb, var(--color-accent) 50%, var(--color-highlight)));
+}
+
+.operation-card__actions {
+  margin-top: var(--space-3);
+  display: flex;
+  justify-content: flex-end;
+}

--- a/index.html
+++ b/index.html
@@ -192,12 +192,12 @@
                 <span class="command-tile__meta" data-field="command-upgrade-status">No systems unlocked</span>
                 <span class="command-tile__summary" data-field="command-upgrade-summary">Earn cash to unlock new tech.</span>
               </button>
-              <button class="command-tile" type="button" data-module-target="meta-preview" data-module-label="Mission Brief">
-                <span class="command-tile__icon" aria-hidden="true">📡</span>
-                <span class="command-tile__eyebrow">Meta</span>
-                <span class="command-tile__title">Mission Brief</span>
-                <span class="command-tile__meta" data-field="command-meta-status">0 research credits</span>
-                <span class="command-tile__summary" data-field="command-meta-summary">Chart long-term upgrades from Mission Control.</span>
+              <button class="command-tile" type="button" data-module-target="operations" data-module-label="Operations Board">
+                <span class="command-tile__icon" aria-hidden="true">🧭</span>
+                <span class="command-tile__eyebrow">Contracts</span>
+                <span class="command-tile__title">Operations Board</span>
+                <span class="command-tile__meta" data-field="command-operations-status">No contracts assigned</span>
+                <span class="command-tile__summary" data-field="command-operations-summary">Complete tactical contracts to earn cash and reputation.</span>
               </button>
             </div>
           </section>
@@ -245,13 +245,14 @@
           <div class="upgrade-status is-hidden" data-element="upgrade-status" aria-live="polite"></div>
           <div class="upgrade-grid" data-region="upgrade-list" data-module-focus></div>
         </section>
-        <section class="module-screen" data-module="meta-preview" data-module-screen="meta-preview" aria-hidden="true">
+        <section class="module-screen" data-module="operations" data-module-screen="operations" aria-hidden="true">
           <header class="module-screen__header">
-            <h3>Mission Brief</h3>
-            <p>Space reserved for tutorials, goals, or meta progression.</p>
+            <h3>Operations Board</h3>
+            <p>Contracted logistics objectives that reward tactical trading execution.</p>
           </header>
-          <div class="meta-preview">
-            <p>Coming soon: guideposts for your next moonshot. Feature packs can mount here without reworking the dashboard layout.</p>
+          <div class="operations-summary" data-region="operations-summary"></div>
+          <div class="operations-list" data-region="operations-list" data-module-focus>
+            <div class="operations-empty" data-element="operations-empty">No contracts assigned yet.</div>
           </div>
         </section>
       </div>

--- a/js/core/gameEngine.js
+++ b/js/core/gameEngine.js
@@ -1,4 +1,5 @@
 import { createDailySnapshot, normalizeDailyStats } from "./daySummary.js";
+import { createOperationsState, ensureOperationsState } from "./operations.js";
 
 const DEFAULT_SAVE_KEY = "ttm_v0_save";
 const DEFAULT_TICK_INTERVAL = 600;
@@ -85,6 +86,7 @@ export function createInitialState({
       }
     }
   };
+  state.operations = createOperationsState();
   state.dailyStats = createDailySnapshot(state);
   state.previousDailyStats = null;
   state.lastDaySummary = null;
@@ -221,6 +223,36 @@ function normalizeState(raw, { dayDurationMs = DEFAULT_DAY_DURATION_MS } = {}) {
         : {},
     nextScenarioId: Number.isFinite(raw.nextScenarioId) ? raw.nextScenarioId : base.nextScenarioId
   };
+
+  state.operations = raw.operations && typeof raw.operations === "object"
+    ? {
+        ...createOperationsState(),
+        ...raw.operations,
+        contracts: Array.isArray(raw.operations.contracts)
+          ? raw.operations.contracts
+              .map((contract) => {
+                if (!contract || typeof contract !== "object") return null;
+                if (typeof contract.id !== "string") return null;
+                if (typeof contract.assetId !== "string") return null;
+                return {
+                  id: contract.id,
+                  label: typeof contract.label === "string" ? contract.label : "Contract",
+                  assetId: contract.assetId,
+                  side: contract.side === "buy" || contract.side === "sell" ? contract.side : "either",
+                  targetQty: Number.isFinite(contract.targetQty) ? Math.max(1, Math.floor(contract.targetQty)) : 1,
+                  progressQty: Number.isFinite(contract.progressQty) ? Math.max(0, Math.floor(contract.progressQty)) : 0,
+                  rewardCash: Number.isFinite(contract.rewardCash) ? contract.rewardCash : 0,
+                  rewardRep: Number.isFinite(contract.rewardRep) ? contract.rewardRep : 0,
+                  issuedDay: Number.isFinite(contract.issuedDay) ? contract.issuedDay : 1,
+                  dueDay: Number.isFinite(contract.dueDay) ? contract.dueDay : 2,
+                  status: typeof contract.status === "string" ? contract.status : "active"
+                };
+              })
+              .filter(Boolean)
+          : []
+      }
+    : createOperationsState();
+  ensureOperationsState(state);
 
   // Ensure feed entries always have defaults.
   state.feed = state.feed.map((entry) => ({

--- a/js/core/operations.js
+++ b/js/core/operations.js
@@ -1,0 +1,167 @@
+const DEFAULT_TARGET_RANGE = [40, 180];
+const DEFAULT_REWARD_RANGE = [450, 2200];
+const DEFAULT_CONTRACTS_PER_DAY = 3;
+
+const pick = (list, random = Math.random) => {
+  if (!Array.isArray(list) || !list.length) return null;
+  const index = Math.floor(Math.max(0, Math.min(0.9999, random())) * list.length);
+  return list[index] ?? list[list.length - 1];
+};
+
+const rollRange = ([min, max], random = Math.random) => {
+  const low = Number.isFinite(min) ? min : 1;
+  const high = Number.isFinite(max) ? Math.max(low, max) : low;
+  return Math.round(low + (high - low) * random());
+};
+
+export function createOperationsState() {
+  return {
+    reputation: 0,
+    completed: 0,
+    failed: 0,
+    contracts: [],
+    nextContractId: 1,
+    lastIssuedDay: 0
+  };
+}
+
+export function ensureOperationsState(state) {
+  if (!state || typeof state !== "object") return createOperationsState();
+  if (!state.operations || typeof state.operations !== "object") {
+    state.operations = createOperationsState();
+    return state.operations;
+  }
+  const ops = state.operations;
+  if (!Array.isArray(ops.contracts)) ops.contracts = [];
+  if (!Number.isFinite(ops.reputation)) ops.reputation = 0;
+  if (!Number.isFinite(ops.completed)) ops.completed = 0;
+  if (!Number.isFinite(ops.failed)) ops.failed = 0;
+  if (!Number.isFinite(ops.nextContractId) || ops.nextContractId < 1) ops.nextContractId = 1;
+  if (!Number.isFinite(ops.lastIssuedDay) || ops.lastIssuedDay < 0) ops.lastIssuedDay = 0;
+  return ops;
+}
+
+function createContract(state, { random = Math.random } = {}) {
+  const ops = ensureOperationsState(state);
+  const assets = Array.isArray(state?.assets) ? state.assets : [];
+  const asset = pick(assets, random);
+  if (!asset?.id) return null;
+
+  const side = pick(["buy", "sell", "either"], random) ?? "either";
+  const targetQty = Math.max(10, rollRange(DEFAULT_TARGET_RANGE, random));
+  const dueInDays = pick([1, 2, 2, 3], random) ?? 2;
+  const rewardCash = Math.max(100, rollRange(DEFAULT_REWARD_RANGE, random));
+  const rewardRep = Math.max(1, Math.round(targetQty / 35));
+  const id = `CTR-${ops.nextContractId}`;
+  ops.nextContractId += 1;
+
+  const sideLabel = side === "either" ? "Trade" : side === "buy" ? "Acquire" : "Offload";
+
+  return {
+    id,
+    label: `${sideLabel} ${asset.id} flow`,
+    assetId: asset.id,
+    side,
+    targetQty,
+    progressQty: 0,
+    rewardCash,
+    rewardRep,
+    issuedDay: Number.isFinite(state?.day) ? state.day : 1,
+    dueDay: (Number.isFinite(state?.day) ? state.day : 1) + dueInDays,
+    status: "active"
+  };
+}
+
+export function primeOperationsForDay(state, { random = Math.random, contractsPerDay = DEFAULT_CONTRACTS_PER_DAY } = {}) {
+  const ops = ensureOperationsState(state);
+  const day = Number.isFinite(state?.day) ? state.day : 1;
+
+  if (ops.lastIssuedDay === day) return ops;
+
+  ops.contracts = ops.contracts.filter((contract) => contract && (contract.status === "active" || contract.status === "completed"));
+
+  while (ops.contracts.filter((contract) => contract.status === "active").length < contractsPerDay) {
+    const contract = createContract(state, { random });
+    if (!contract) break;
+    ops.contracts.push(contract);
+  }
+
+  ops.lastIssuedDay = day;
+  return ops;
+}
+
+export function recordOperationsTrade(state, { id, side, qty }) {
+  const ops = ensureOperationsState(state);
+  if (!id || !Number.isFinite(qty) || qty <= 0) return;
+  const tradeSide = side === "sell" ? "sell" : "buy";
+
+  ops.contracts.forEach((contract) => {
+    if (!contract || contract.status !== "active") return;
+    if (contract.assetId !== id) return;
+    if (contract.side !== "either" && contract.side !== tradeSide) return;
+    contract.progressQty = Math.min(contract.targetQty, (contract.progressQty || 0) + qty);
+    if (contract.progressQty >= contract.targetQty) {
+      contract.status = "completed";
+    }
+  });
+}
+
+export function resolveExpiredContracts(state) {
+  const ops = ensureOperationsState(state);
+  const day = Number.isFinite(state?.day) ? state.day : 1;
+  let failedNow = 0;
+
+  ops.contracts.forEach((contract) => {
+    if (!contract || contract.status !== "active") return;
+    if (!Number.isFinite(contract.dueDay)) return;
+    if (day > contract.dueDay) {
+      contract.status = "failed";
+      failedNow += 1;
+    }
+  });
+
+  if (failedNow > 0) {
+    ops.failed += failedNow;
+  }
+
+  return failedNow;
+}
+
+export function claimCompletedContract(state, contractId) {
+  const ops = ensureOperationsState(state);
+  const contract = ops.contracts.find((item) => item?.id === contractId);
+  if (!contract || contract.status !== "completed") {
+    return { success: false };
+  }
+
+  const cashReward = Number.isFinite(contract.rewardCash) ? contract.rewardCash : 0;
+  const repReward = Number.isFinite(contract.rewardRep) ? contract.rewardRep : 0;
+
+  state.cash += cashReward;
+  ops.reputation += repReward;
+  ops.completed += 1;
+  contract.status = "claimed";
+
+  return {
+    success: true,
+    cashReward,
+    repReward,
+    contract
+  };
+}
+
+export function summarizeOperations(state) {
+  const ops = ensureOperationsState(state);
+  const active = ops.contracts.filter((contract) => contract?.status === "active");
+  const completed = ops.contracts.filter((contract) => contract?.status === "completed");
+
+  return {
+    reputation: ops.reputation,
+    completed: ops.completed,
+    failed: ops.failed,
+    activeCount: active.length,
+    readyToClaim: completed.length,
+    activeContracts: active,
+    claimableContracts: completed
+  };
+}

--- a/js/main.js
+++ b/js/main.js
@@ -35,6 +35,15 @@ import { createDailySummaryController } from "./ui/dailySummary.js";
 import { createUpgradeShopController } from "./ui/upgrades.js";
 import { updateInsiderBanner } from "./ui/insiderBanner.js";
 import { createCommandModulesController } from "./ui/commandModules.js";
+import { createOperationsController } from "./ui/operations.js";
+import {
+  ensureOperationsState,
+  primeOperationsForDay,
+  recordOperationsTrade,
+  resolveExpiredContracts,
+  claimCompletedContract,
+  summarizeOperations
+} from "./core/operations.js";
 
 const fmtMoney = (n) =>
   (n < 0 ? "-$" : "$") +
@@ -148,7 +157,8 @@ function refreshCommandModules(currentState = state) {
   if (!controllers.commandModules || !currentState) return;
   controllers.commandModules.render(currentState, {
     feed: currentState.feed ?? [],
-    meta: metaState
+    meta: metaState,
+    operations: summarizeOperations(currentState)
   });
 }
 
@@ -270,6 +280,20 @@ function setupControllers() {
 
   controllers.commandModules = createCommandModulesController();
 
+  controllers.operations = createOperationsController({
+    onClaim: (contractId) => {
+      if (!engine || !contractId) return { success: false };
+      let outcome = { success: false };
+      engine.update((draft) => {
+        const result = claimCompletedContract(draft, contractId);
+        if (!result.success) return;
+        outcome = result;
+        bumpNews(`Contract settled: +${fmtMoney(result.cashReward)} and +${result.repReward} REP.`, { state: draft, tone: "good" });
+      }, { save: true });
+      return outcome;
+    }
+  });
+
   window.__TTM_UI__ = {
     hud: controllers.hud,
     market: controllers.market,
@@ -309,6 +333,8 @@ function handleStartNewRun() {
     dayDurationMs: engine.dayDurationMs
   }));
   state = engine.getState();
+  ensureOperationsState(state);
+  primeOperationsForDay(state);
   refreshCommandModules(state);
   refreshDailyMetrics(state);
   eventSystem.bootstrap(state);
@@ -373,6 +399,8 @@ function init() {
 
   engine = createGameEngine({ state: initialState });
   state = engine.getState();
+  ensureOperationsState(state);
+  primeOperationsForDay(state);
   refreshCommandModules(state);
   refreshDailyMetrics(state);
 
@@ -484,6 +512,7 @@ function renderAll(currentState) {
     lastSelectedAssetId = asset?.id ?? null;
   }
 
+  controllers.operations?.render(currentState);
   refreshCommandModules(currentState);
 }
 
@@ -524,6 +553,7 @@ function recordTrade(currentState, { id, side, qty, price, realized = 0 }) {
     tick: Number.isFinite(currentState.tick) ? currentState.tick : 0,
     day: Number.isFinite(currentState.day) ? currentState.day : 0
   });
+  recordOperationsTrade(currentState, { id, side, qty: units });
   recordTradeStats(currentState, {
     side,
     qty: units,
@@ -580,6 +610,13 @@ function handleTick(currentState) {
 }
 
 function handleDayEnd(currentState, context = {}) {
+  const failedContracts = resolveExpiredContracts(currentState);
+  if (failedContracts > 0) {
+    logFeedEntry(currentState, {
+      text: `${failedContracts} contract${failedContracts === 1 ? "" : "s"} expired before settlement.`,
+      kind: "warn"
+    });
+  }
   const steps = Number.isFinite(context.overnightSteps) ? context.overnightSteps : 6;
   const variance = Number.isFinite(context.varianceBoost) ? context.varianceBoost : 1.8;
   stepAll(currentState, steps, variance);
@@ -628,6 +665,7 @@ function handleDayEnd(currentState, context = {}) {
     const advanceState = (draft) => {
       draft.day += 1;
       startNewDay(draft);
+      primeOperationsForDay(draft);
 
       const accrueInterest = window.Upgrades?.accrueDailyInterest;
       if (typeof accrueInterest === "function") {

--- a/js/ui/commandModules.js
+++ b/js/ui/commandModules.js
@@ -1,5 +1,4 @@
 import { UPGRADE_DEF } from "../core/upgrades.js";
-import { META_CURRENCY_SYMBOL } from "../core/metaProgression.js";
 
 const FOCUSABLE_SELECTOR = [
   "a[href]",
@@ -15,10 +14,6 @@ const formatMoney = (value) => {
   return `$${amount.toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
 };
 
-const formatCredits = (value) => {
-  const amount = Number.isFinite(value) ? value : 0;
-  return `${amount.toLocaleString()} ${META_CURRENCY_SYMBOL}`.trim();
-};
 
 const getFocusable = (root) => {
   if (!root) return [];
@@ -34,23 +29,6 @@ const summarizeEvent = (event) => {
   return "Scenario awaiting orders.";
 };
 
-const summarizeMeta = (meta) => {
-  if (!meta || typeof meta !== "object") return "Chart long-term upgrades from Mission Control.";
-  if (meta.lastSummary && typeof meta.lastSummary === "object") {
-    const label = meta.lastSummary.label || meta.lastSummary.reason || null;
-    const net = Number.isFinite(meta.lastSummary.netWorth) ? meta.lastSummary.netWorth : null;
-    if (label && net != null) {
-      return `${label} · Net ${formatMoney(net)}`;
-    }
-    if (label) return label;
-  }
-  const runs = Number.isFinite(meta.lifetime?.runs) ? meta.lifetime.runs : 0;
-  if (runs > 0) {
-    const best = Number.isFinite(meta.lifetime?.bestNetWorth) ? meta.lifetime.bestNetWorth : null;
-    return best != null ? `Best run ${formatMoney(best)} · ${runs} logged` : `${runs} runs completed.`;
-  }
-  return "Chart long-term upgrades from Mission Control.";
-};
 
 export function createCommandModulesController() {
   const root = document.querySelector('[data-module="command-modules"]');
@@ -84,8 +62,8 @@ export function createCommandModulesController() {
     newsSummary: root.querySelector('[data-field="command-news-summary"]'),
     upgradesStatus: root.querySelector('[data-field="command-upgrade-status"]'),
     upgradesSummary: root.querySelector('[data-field="command-upgrade-summary"]'),
-    metaStatus: root.querySelector('[data-field="command-meta-status"]'),
-    metaSummary: root.querySelector('[data-field="command-meta-summary"]')
+    operationsStatus: root.querySelector('[data-field="command-operations-status"]'),
+    operationsSummary: root.querySelector('[data-field="command-operations-summary"]')
   };
 
   let openId = null;
@@ -251,16 +229,29 @@ export function createCommandModulesController() {
     }
   };
 
-  const updateMetaSummary = (meta) => {
-    if (fields.metaStatus) {
-      fields.metaStatus.textContent = formatCredits(meta?.currency);
+  const updateOperationsSummary = (operations) => {
+    const active = Number.isFinite(operations?.activeCount) ? operations.activeCount : 0;
+    const claimable = Number.isFinite(operations?.readyToClaim) ? operations.readyToClaim : 0;
+    const rep = Number.isFinite(operations?.reputation) ? operations.reputation : 0;
+
+    if (fields.operationsStatus) {
+      const parts = [`${active} active`, `${rep} REP`];
+      fields.operationsStatus.textContent = parts.join(" · ");
     }
-    if (fields.metaSummary) {
-      fields.metaSummary.textContent = summarizeMeta(meta);
+
+    if (fields.operationsSummary) {
+      if (claimable > 0) {
+        fields.operationsSummary.textContent = `${claimable} contract${claimable === 1 ? "" : "s"} ready to claim.`;
+      } else if (active > 0) {
+        fields.operationsSummary.textContent = "Push trade flow to complete contracts before deadlines.";
+      } else {
+        fields.operationsSummary.textContent = "No contracts assigned";
+      }
     }
-    const tile = buttonMap.get("meta-preview");
+
+    const tile = buttonMap.get("operations");
     if (tile) {
-      if (Number.isFinite(meta?.currency) && meta.currency > 0) {
+      if (claimable > 0) {
         tile.dataset.tone = "alert";
       } else {
         delete tile.dataset.tone;
@@ -269,11 +260,11 @@ export function createCommandModulesController() {
   };
 
   return {
-    render(state, { feed = [], meta } = {}) {
+    render(state, { feed = [], operations } = {}) {
       updateEventsSummary(state);
       updateNewsSummary(feed);
       updateUpgradeSummary(state);
-      updateMetaSummary(meta);
+      updateOperationsSummary(operations);
     },
     open,
     close

--- a/js/ui/operations.js
+++ b/js/ui/operations.js
@@ -1,0 +1,100 @@
+import { summarizeOperations } from "../core/operations.js";
+
+const formatMoney = (value) => {
+  const amount = Number.isFinite(value) ? value : 0;
+  return `$${amount.toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
+};
+
+const progressLabel = (contract) => {
+  const progress = Number.isFinite(contract?.progressQty) ? contract.progressQty : 0;
+  const target = Number.isFinite(contract?.targetQty) ? contract.targetQty : 0;
+  return `${Math.min(progress, target)}/${target}`;
+};
+
+export function createOperationsController({ onClaim } = {}) {
+  const root = document.querySelector('[data-module="operations"]');
+  if (!root) {
+    return { render() {} };
+  }
+
+  const summaryEl = root.querySelector('[data-region="operations-summary"]');
+  const listEl = root.querySelector('[data-region="operations-list"]');
+  const emptyEl = root.querySelector('[data-element="operations-empty"]');
+
+  const claim = (contractId) => {
+    if (!contractId || typeof onClaim !== "function") return;
+    onClaim(contractId);
+  };
+
+  const renderContract = (contract, { claimable = false } = {}) => {
+    const article = document.createElement("article");
+    article.className = `operation-card${claimable ? " operation-card--claimable" : ""}`;
+
+    const sideLabel = contract.side === "either" ? "BUY/SELL" : contract.side.toUpperCase();
+    const progress = Number.isFinite(contract.targetQty) && contract.targetQty > 0
+      ? Math.min(100, Math.round(((contract.progressQty || 0) / contract.targetQty) * 100))
+      : 0;
+
+    article.innerHTML = `
+      <header class="operation-card__header">
+        <div>
+          <p class="operation-card__eyebrow">${sideLabel} · ${contract.assetId}</p>
+          <h4>${contract.label}</h4>
+        </div>
+        <div class="operation-card__reward">${formatMoney(contract.rewardCash)} · +${contract.rewardRep} REP</div>
+      </header>
+      <div class="operation-card__progress">
+        <span>Flow ${progressLabel(contract)}</span>
+        <span>DUE D${contract.dueDay}</span>
+      </div>
+      <div class="operation-card__bar"><span style="width:${progress}%;"></span></div>
+    `;
+
+    if (claimable) {
+      const actions = document.createElement("div");
+      actions.className = "operation-card__actions";
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "btn btn-primary";
+      button.textContent = "Claim Reward";
+      button.addEventListener("click", () => claim(contract.id));
+      actions.appendChild(button);
+      article.appendChild(actions);
+    }
+
+    return article;
+  };
+
+  return {
+    render(state) {
+      const summary = summarizeOperations(state);
+      if (summaryEl) {
+        summaryEl.innerHTML = `
+          <div class="operations-pill">REP <strong>${summary.reputation}</strong></div>
+          <div class="operations-pill">ACTIVE <strong>${summary.activeCount}</strong></div>
+          <div class="operations-pill">READY <strong>${summary.readyToClaim}</strong></div>
+          <div class="operations-pill">COMPLETED <strong>${summary.completed}</strong></div>
+          <div class="operations-pill">FAILED <strong>${summary.failed}</strong></div>
+        `;
+      }
+
+      if (!listEl) return;
+      listEl.querySelectorAll('.operation-card').forEach((node) => node.remove());
+
+      const claimable = summary.claimableContracts || [];
+      const active = summary.activeContracts || [];
+
+      const hasAny = claimable.length + active.length > 0;
+      if (emptyEl) {
+        emptyEl.style.display = hasAny ? "none" : "block";
+      }
+
+      claimable.forEach((contract) => {
+        listEl.appendChild(renderContract(contract, { claimable: true }));
+      });
+      active.forEach((contract) => {
+        listEl.appendChild(renderContract(contract));
+      });
+    }
+  };
+}


### PR DESCRIPTION
### Motivation
- Tighten the core gameplay loop by introducing short-term tactical objectives that reward trading activity and create a clear pathway for future subsystems to dock into the command deck.  
- Keep the implementation modular so new systems can plug into the runtime and UI without breaking the market/run flow.  
- Surface operational objectives and claimable rewards in the dashboard to improve tactical clarity and make the three-column command deck meaningful.  
- Persist and normalize operations data so contracts survive save/load and scale with run lifecycle.

### Description
- Added a new core module `js/core/operations.js` that implements procedural daily contracts, contract progression from trades, expiry resolution, claiming rewards, and summaries via `createOperationsState`, `primeOperationsForDay`, `recordOperationsTrade`, `resolveExpiredContracts`, `claimCompletedContract`, and `summarizeOperations`.  
- Integrated operations state and normalization into the game lifecycle in `js/core/gameEngine.js` and `js/main.js`, including creating operations on initial state, normalizing loaded operations, priming contracts on run start/day start, resolving expirations at day end, and advancing progress on each trade.  
- Added a dedicated UI controller `js/ui/operations.js` and an Operations Board module screen/tile in `index.html` to present contract cards, progress bars, claim actions, and summary pills.  
- Updated command-dock behavior in `js/ui/commandModules.js` to surface live operations telemetry (active contracts, claimables, REP) and alerting on claimable contracts.  
- Added styles in `css/styles.css` for operations summary pills, contract cards, progress bars, and claim emphasis to match the existing command-deck aesthetic.  
- Wired an operations controller to the main controller set so claim actions call `claimCompletedContract` and award cash + reputation via the engine update API.

### Testing
- Ran syntax checks with `node --check` across the modified modules: `js/main.js`, `js/core/gameEngine.js`, `js/core/operations.js`, `js/ui/commandModules.js`, and `js/ui/operations.js` which all passed.  
- Attempted automated runtime validation and a Playwright screenshot of the updated Operations UI; the browser run failed in this environment due to unstable headless browser startup/segfaults, so visual verification was not captured automatically.  
- Confirmed the new modules load without syntax errors and that the operations API is callable through the engine (sanity checks performed via scripted engine interactions during development).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d1980391c832a98647d2b8d8be0ea)